### PR TITLE
Improve recipe list performance

### DIFF
--- a/src/components/Toolbar/SearchBar/SearchBar.tsx
+++ b/src/components/Toolbar/SearchBar/SearchBar.tsx
@@ -7,9 +7,21 @@ import type {
 import { useRouter } from "next/router";
 
 import { useSearchBox } from "../../../context";
+import { useDebounce } from "../../../hooks";
 
 export const SearchBar = () => {
   const { searchBoxValue = "", onSearchBoxValueChange } = useSearchBox();
+
+  const [inputValue, setInputValue] = React.useState(searchBoxValue);
+  const debouncedValue = useDebounce(inputValue, 300);
+
+  React.useEffect(() => {
+    onSearchBoxValueChange(debouncedValue);
+  }, [debouncedValue, onSearchBoxValueChange]);
+
+  React.useEffect(() => {
+    setInputValue(searchBoxValue);
+  }, [searchBoxValue]);
 
   const router = useRouter();
   const path = router.asPath;
@@ -18,7 +30,7 @@ export const SearchBar = () => {
     _ev: SearchBoxChangeEvent,
     data: InputOnChangeData
   ) => {
-    onSearchBoxValueChange(data.value);
+    setInputValue(data.value);
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,7 +45,7 @@ export const SearchBar = () => {
 
   return (
     <SearchBox
-      value={searchBoxValue}
+      value={inputValue}
       onChange={onSearchBarChange}
       appearance="outline"
       placeholder="Search for snacks"

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./useMediaQuery";
 export * from "./useThemeDetector";
+export * from "./useDebounce";

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,14 @@
+import * as React from "react";
+
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+  React.useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
- debounce recipe search to avoid excessive API calls
- add generic `useDebounce` hook

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6848b95626cc8324b07e52f0c098cb2d