### PR TITLE
Add unit tests for recipe and AI API routes

### DIFF
--- a/src/pages/api/ai/processRecipe.test.ts
+++ b/src/pages/api/ai/processRecipe.test.ts
@@ -1,0 +1,45 @@
+/** @jest-environment node */
+
+import handler from './processRecipe';
+import { processWithAI } from '../../../server';
+
+jest.mock('../../../server', () => ({
+  processWithAI: jest.fn(),
+}));
+
+describe('/api/ai/processRecipe', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('rejects non-POST requests', async () => {
+    const req = { method: 'GET' } as any;
+    const res = await handler(req);
+    const body = await res.json();
+    expect(res.status).toBe(405);
+    expect(body).toEqual({ message: 'Method Not Allowed' });
+  });
+
+  test('returns 400 when htmlContent missing', async () => {
+    const req = { method: 'POST', json: jest.fn().mockResolvedValue({}) } as any;
+    const res = await handler(req);
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ message: 'Missing or invalid htmlContent in request body' });
+  });
+
+  test('returns processed content on success', async () => {
+    const req = { method: 'POST', json: jest.fn().mockResolvedValue({ htmlContent: '<p>hi</p>' }) } as any;
+    (processWithAI as jest.Mock).mockResolvedValue({ processedContent: '<p>out</p>' });
+
+    const res = await handler(req);
+    const body = await res.json();
+
+    expect(processWithAI).toHaveBeenCalledWith({
+      systemPrompt: expect.any(String),
+      userPrompt: '<p>hi</p>',
+    });
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ processedContent: '<p>out</p>' });
+  });
+});

--- a/src/pages/api/recipes/index.test.ts
+++ b/src/pages/api/recipes/index.test.ts
@@ -1,0 +1,67 @@
+/** @jest-environment node */
+
+jest.mock('../auth/[...nextauth]', () => ({ authOptions: {} }));
+jest.mock('src/utils', () => ({ getDb: jest.fn() }));
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }));
+
+import handler from './index';
+import { getDb } from 'src/utils';
+import { getServerSession } from 'next-auth';
+
+const mockRes = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn(),
+  } as any;
+  return res;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('/api/recipes', () => {
+  test('GET invalid sort parameter returns 400', async () => {
+    const req = { method: 'GET', query: { sortProperty: 'invalid' } } as any;
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid sorting parameters.' });
+  });
+
+  test('POST without session returns 401', async () => {
+    const req = { method: 'POST', body: { title: 'Test' } } as any;
+    const res = mockRes();
+
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  test('POST with session inserts recipe', async () => {
+    const req = {
+      method: 'POST',
+      body: { title: 'Title', data: {}, tags: [] },
+    } as any;
+    const res = mockRes();
+
+    const insertOne = jest.fn().mockResolvedValue({ insertedId: '123' });
+    const db = { collection: jest.fn().mockReturnValue({ insertOne }) } as any;
+    (getDb as jest.Mock).mockResolvedValue(db);
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: 'user1' } });
+
+    await handler(req, res);
+
+    expect(insertOne).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Recipe uploaded successfully.',
+      recipeId: '123',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `/api/recipes` route
- add unit tests for `/api/ai/processRecipe` route

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6848bf0a45988324a5c57dadfde0e685