### PR TITLE
Add star rating

### DIFF
--- a/src/clientToServer/post/useUpdateRecipe.ts
+++ b/src/clientToServer/post/useUpdateRecipe.ts
@@ -27,6 +27,7 @@ export function useUpdateRecipe(recipeId: string | undefined) {
         imageURL: DOMPurify.sanitize(String(updatedRecipeData.imageURL || "")),
         emoji: DOMPurify.sanitize(String(updatedRecipeData.emoji || "")),
         isPublic: Boolean(updatedRecipeData.isPublic),
+        rating: Number(updatedRecipeData.rating ?? 0),
       };
 
       try {

--- a/src/clientToServer/types/recipes.types.ts
+++ b/src/clientToServer/types/recipes.types.ts
@@ -36,6 +36,11 @@ export type Recipe = {
   emoji: string;
 
   /**
+   * Numerical rating for the recipe from 0 to 5.
+   */
+  rating: number;
+
+  /**
    * The owner of the recipe.
    */
   owner: string;
@@ -53,6 +58,7 @@ export type UpdateRecipePayload = {
   imageURL: string;
   emoji: string;
   isPublic: boolean;
+  rating: number;
 };
 
 export type CreateRecipeResponse = { message: string; recipeId: string };

--- a/src/components/RecipeCard/RecipeCard.styles.ts
+++ b/src/components/RecipeCard/RecipeCard.styles.ts
@@ -72,6 +72,9 @@ export const useRecipeCardStyles = makeStyles({
   headerAction: {
     flexShrink: 0,
   },
+  ratingRow: {
+    marginBottom: "8px",
+  },
   tagsContainer: {
     display: "flex",
     flexWrap: "wrap",

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import { useRecipeCardStyles } from "./RecipeCard.styles";
 import type { RecipeCardProps } from "./RecipeCard.types";
 import { RecipeActions } from "../RecipeActions";
+import { StarRating } from "../StarRating";
 
 export const RecipeCard: React.FC<RecipeCardProps> = (props) => {
   const {
@@ -16,7 +17,8 @@ export const RecipeCard: React.FC<RecipeCardProps> = (props) => {
     id,
     emoji,
     isMinimal,
-    isPublic
+    isPublic,
+    rating,
   } = props;
   const router = useRouter();
   const cardRef = React.useRef<HTMLDivElement>(null);
@@ -119,6 +121,11 @@ export const RecipeCard: React.FC<RecipeCardProps> = (props) => {
               </div>
             )}
           </div>
+          {!isMinimal && (
+            <div className={styles.ratingRow}>
+              <StarRating rating={rating} readOnly size={16} />
+            </div>
+          )}
           {!isMinimal && tags && tags.length > 0 && (
             <div className={styles.tagsContainer}>
               {tags.slice(0, 3).map((tag, i) => (

--- a/src/components/RecipeCard/RecipeCard.types.ts
+++ b/src/components/RecipeCard/RecipeCard.types.ts
@@ -30,6 +30,11 @@ export type RecipeCardProps = {
   emoji: string;
 
   /**
+   * Rating for the recipe.
+   */
+  rating: number;
+
+  /**
    * Whether to render the card in a minimal style.
    */
   isMinimal?: boolean;

--- a/src/components/RecipeGallery/RecipeGallery.tsx
+++ b/src/components/RecipeGallery/RecipeGallery.tsx
@@ -159,6 +159,7 @@ export const RecipeGallery = () => {
                     }
                     imageSrc={recipe?.imageURL}
                     tags={recipe?.tags}
+                    rating={recipe?.rating || 0}
                   />
                 </div>
               );

--- a/src/components/RecipePage/RecipeHeader/RecipeHeader.tsx
+++ b/src/components/RecipePage/RecipeHeader/RecipeHeader.tsx
@@ -16,6 +16,7 @@ import { motion } from "framer-motion";
 import { useHeaderStyles } from "./RecipeHeader.styles";
 import { RecipeHeaderSaveBar } from "./RecipeHeaderSaveBar";
 import { RecipeAuthor } from "../RecipeAuthor/RecipeAuthor";
+import { StarRating } from "../../StarRating";
 
 import { useConvertMeasurements } from "../../../clientToServer";
 import { useRecipe } from "../../../context";
@@ -146,6 +147,13 @@ export const RecipeHeader = () => {
         />
         <div className={styles.subContentContainer}>
           <RecipeAuthor />
+          <StarRating
+            rating={editableData.rating}
+            onChange={(value) => {
+              updateEditableDataKey("rating", value);
+              saveChanges({ rating: value });
+            }}
+          />
           {formattedDate && (
             <Text block italic className={styles.date}>
               Created: {formattedDate}

--- a/src/components/StarRating/StarRating.tsx
+++ b/src/components/StarRating/StarRating.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { makeStyles, shorthands, tokens } from "@fluentui/react-components";
+import { StarFilled, StarRegular } from "@fluentui/react-icons";
+
+export type StarRatingProps = {
+  rating: number;
+  onChange?: (value: number) => void;
+  readOnly?: boolean;
+  size?: number;
+};
+
+const useStyles = makeStyles({
+  root: {
+    display: "inline-flex",
+    alignItems: "center",
+    ...shorthands.gap("2px"),
+    color: tokens.colorPaletteYellowForeground2,
+  },
+  star: {
+    cursor: "pointer",
+  },
+});
+
+export const StarRating: React.FC<StarRatingProps> = ({
+  rating,
+  onChange,
+  readOnly,
+  size = 16,
+}) => {
+  const styles = useStyles();
+  const handleClick = (value: number) => {
+    if (!readOnly && onChange) {
+      onChange(value);
+    }
+  };
+
+  return (
+    <div className={styles.root} onClick={(e) => e.stopPropagation()}>
+      {Array.from({ length: 5 }).map((_, idx) => {
+        const value = idx + 1;
+        const Filled = value <= rating ? StarFilled : StarRegular;
+        return (
+          <Filled
+            key={value}
+            fontSize={size}
+            className={styles.star}
+            onClick={() => handleClick(value)}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/StarRating/index.ts
+++ b/src/components/StarRating/index.ts
@@ -1,0 +1,1 @@
+export * from './StarRating';

--- a/src/components/Toolbar/NewRecipeDialog/NewRecipeDialog.tsx
+++ b/src/components/Toolbar/NewRecipeDialog/NewRecipeDialog.tsx
@@ -122,6 +122,7 @@ export const NewRecipeDialog: React.FC<NewRecipeDialogProps> = ({
         imageURL: "",
         emoji: "",
         isPublic: false,
+        rating: 0,
       },
       {
         onSuccess: async (data) => {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,3 +3,4 @@ export * from "./Toolbar";
 export * from "./FallbackScreens";
 export * from "./RecipeCard";
 export * from "./TagPicker";
+export * from "./StarRating";

--- a/src/context/RecipeProvider/RecipeProvider.tsx
+++ b/src/context/RecipeProvider/RecipeProvider.tsx
@@ -37,6 +37,7 @@ export const RecipeProvider: React.FC<{
     emoji: "",
     _id: undefined,
     isPublic: false,
+    rating: 0,
   });
 
   const { mutate: deleteMutate } = useDeleteRecipe();
@@ -88,6 +89,7 @@ export const RecipeProvider: React.FC<{
           imageURL: editableData?.imageURL,
           emoji: editableData?.emoji,
           isPublic: editableData?.isPublic || false,
+          rating: editableData?.rating || 0,
         },
         ...(immediateUpdate || {}),
       });
@@ -99,6 +101,7 @@ export const RecipeProvider: React.FC<{
         imageURL: editableData.imageURL,
         emoji: editableData?.emoji || "",
         isPublic: editableData.isPublic || false,
+        rating: editableData.rating || 0,
       });
     }
   };
@@ -112,6 +115,7 @@ export const RecipeProvider: React.FC<{
         imageURL: recipe.imageURL || "",
         emoji: recipe.emoji || "",
         isPublic: recipe.isPublic || false,
+        rating: recipe.rating || 0,
       };
       setEditableData(initialData);
     }
@@ -151,6 +155,7 @@ export const RecipeProvider: React.FC<{
         imageURL: recipe.imageURL || "",
         emoji: recipe.emoji || "",
         isPublic: recipe.isPublic || false,
+        rating: recipe.rating || 0,
       };
       setEditableData(initialData);
     }
@@ -167,6 +172,7 @@ export const RecipeProvider: React.FC<{
       imageURL: recipe.imageURL || "",
       emoji: recipe.emoji || "",
       isPublic: recipe.isPublic || false,
+      rating: recipe.rating || 0,
     };
   }, [recipe]);
 

--- a/src/context/RecipeProvider/RecipeProvider.types.ts
+++ b/src/context/RecipeProvider/RecipeProvider.types.ts
@@ -8,6 +8,7 @@ export type EditableData = {
   emoji: string;
   _id?: string;
   isPublic?: boolean;
+  rating: number;
 };
 
 export type RecipeContextType = {

--- a/src/pages/api/recipes/[id].ts
+++ b/src/pages/api/recipes/[id].ts
@@ -15,6 +15,7 @@ type UpdateFields = {
   imageURL?: string;
   emoji?: string;
   isPublic?: boolean;
+  rating?: number;
 };
 
 type ResponseData =
@@ -162,7 +163,7 @@ export default async function handler(
         return;
       }
 
-      const { title, data, tags, imageURL, emoji, isPublic } = req.body;
+      const { title, data, tags, imageURL, emoji, isPublic, rating } = req.body;
       const setFields: UpdateFields = {};
       const addToSetFields: UpdateFields = {};
 
@@ -181,6 +182,9 @@ export default async function handler(
       }
       if (isPublic !== undefined) {
         setFields.isPublic = isPublic;
+      }
+      if (rating !== undefined) {
+        setFields.rating = Number(rating);
       }
       if (tags) {
         setFields.tags = tags;

--- a/src/pages/api/recipes/index.ts
+++ b/src/pages/api/recipes/index.ts
@@ -16,6 +16,7 @@ interface RecipeDocument {
   createdAt: Date;
   emoji: string;
   imageURL: string;
+  rating: number;
 }
 
 type VisibilityCondition =
@@ -123,7 +124,7 @@ const handlePostRequest = async (
         .json({ message: "Unauthorized. Please log in to create a recipe." });
     }
 
-    const { title, data, tags } = req.body;
+    const { title, data, tags, rating } = req.body;
 
     if (!title || typeof title !== "string" || !title.trim()) {
       return res.status(400).json({ message: "Title required." });
@@ -140,6 +141,7 @@ const handlePostRequest = async (
       createdAt: new Date(),
       emoji: "🍽️",
       imageURL: "",
+      rating: typeof rating === "number" ? rating : 0,
     };
 
     const result = await db.collection("recipes").insertOne(newRecipe);


### PR DESCRIPTION
## Summary
- add new `StarRating` component
- store rating in API and recipe context
- display rating on recipe cards and header
- allow rating updates

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6848c4b4e6a08324aff2bffd99b55ca8