### PR TITLE
Add storybook providers and theme toggle

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,21 @@
 import type { Preview } from "@storybook/nextjs";
+import { withProviders } from "../src/stories/decorators";
+
+export const globalTypes = {
+  themeMode: {
+    name: "Theme",
+    description: "Toggle light and dark mode",
+    defaultValue: "light",
+    toolbar: {
+      icon: "circlehollow",
+      items: [
+        { value: "light", title: "Light" },
+        { value: "dark", title: "Dark" },
+      ],
+      dynamicTitle: true,
+    },
+  },
+};
 
 const preview: Preview = {
   parameters: {
@@ -9,6 +26,7 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [withProviders],
 };
 
 export default preview;

--- a/src/components/RecipeActions/ChangeEmojiDialog.tsx
+++ b/src/components/RecipeActions/ChangeEmojiDialog.tsx
@@ -135,12 +135,6 @@ const useStyles = makeStyles({
   },
 });
 
-type EmojiEntry = {
-  emoji: string;
-  name: string;
-  keywords: string[];
-};
-
 const isSingleEmoji = (value: string): boolean => {
   if (!value) {
     return false;

--- a/src/components/RecipeActions/ChangeSharedWithDialog.tsx
+++ b/src/components/RecipeActions/ChangeSharedWithDialog.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { Button, makeStyles, Switch, tokens } from "@fluentui/react-components";
 
 import { ChangeDialog } from "./ChangeDialog";
-import { FadeIn } from "../Animation";
 
 const useStyles = makeStyles({
   textArea: {

--- a/src/stories/AppHomePage.stories.tsx
+++ b/src/stories/AppHomePage.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import HomePage from '../components/HomePage/HomePage';
+
+const meta: Meta<typeof HomePage> = {
+  title: 'Pages/HomePage',
+  component: HomePage,
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof HomePage> = {};
+

--- a/src/stories/AppHomePage.stories.tsx
+++ b/src/stories/AppHomePage.stories.tsx
@@ -1,12 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/nextjs';
-import HomePage from '../components/HomePage/HomePage';
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+import HomePage from "../components/HomePage/HomePage";
 
 const meta: Meta<typeof HomePage> = {
-  title: 'Pages/HomePage',
+  title: "Pages/HomePage",
   component: HomePage,
 };
 
 export default meta;
 
 export const Default: StoryObj<typeof HomePage> = {};
-

--- a/src/stories/decorators.tsx
+++ b/src/stories/decorators.tsx
@@ -1,23 +1,31 @@
-import * as React from 'react';
-import { QueryClientProvider } from '@tanstack/react-query';
-import { RendererProvider, createDOMRenderer } from '@griffel/react';
-import { SSRProvider } from '@fluentui/react-utilities';
+import * as React from "react";
+import { SSRProvider } from "@fluentui/react-utilities";
+import { RendererProvider, createDOMRenderer } from "@griffel/react";
+import { QueryClientProvider } from "@tanstack/react-query";
 
-import { queryClient } from '../clients/react-query';
-import { AppContainer } from '../components';
-import { useTheme } from '../context';
-import type { ThemePreference } from '../context/ThemeProvider';
+import { queryClient } from "../clients/react-query";
+import { AppContainer } from "../components";
+import { useTheme } from "../context";
+import type { ThemePreference } from "../context/ThemeProvider";
 
-const ThemeSync: React.FC<{ preference: ThemePreference; children: React.ReactNode }> = ({ preference, children }) => {
+const ThemeSync: React.FC<{
+  preference: ThemePreference;
+  children: React.ReactNode;
+}> = ({ preference, children }) => {
   const { setThemePreference } = useTheme();
   React.useEffect(() => {
     setThemePreference(preference);
   }, [preference, setThemePreference]);
+  // eslint-disable-next-line react/jsx-no-useless-fragment
   return <>{children}</>;
 };
 
-export const withProviders = (Story: React.FC, context: { globals: { themeMode?: ThemePreference } }) => {
-  const preference: ThemePreference = (context.globals.themeMode as ThemePreference) || 'light';
+export const withProviders = (
+  Story: React.FC,
+  context: { globals: { themeMode?: ThemePreference } }
+) => {
+  const preference: ThemePreference =
+    (context.globals.themeMode as ThemePreference) || "light";
   return (
     <QueryClientProvider client={queryClient}>
       <RendererProvider renderer={createDOMRenderer()}>
@@ -32,4 +40,3 @@ export const withProviders = (Story: React.FC, context: { globals: { themeMode?:
     </QueryClientProvider>
   );
 };
-

--- a/src/stories/decorators.tsx
+++ b/src/stories/decorators.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { RendererProvider, createDOMRenderer } from '@griffel/react';
+import { SSRProvider } from '@fluentui/react-utilities';
+
+import { queryClient } from '../clients/react-query';
+import { AppContainer } from '../components';
+import { useTheme } from '../context';
+import type { ThemePreference } from '../context/ThemeProvider';
+
+const ThemeSync: React.FC<{ preference: ThemePreference; children: React.ReactNode }> = ({ preference, children }) => {
+  const { setThemePreference } = useTheme();
+  React.useEffect(() => {
+    setThemePreference(preference);
+  }, [preference, setThemePreference]);
+  return <>{children}</>;
+};
+
+export const withProviders = (Story: React.FC, context: { globals: { themeMode?: ThemePreference } }) => {
+  const preference: ThemePreference = (context.globals.themeMode as ThemePreference) || 'light';
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RendererProvider renderer={createDOMRenderer()}>
+        <SSRProvider>
+          <AppContainer>
+            <ThemeSync preference={preference}>
+              <Story />
+            </ThemeSync>
+          </AppContainer>
+        </SSRProvider>
+      </RendererProvider>
+    </QueryClientProvider>
+  );
+};
+


### PR DESCRIPTION
## Summary
- add Storybook decorators to wrap stories with app providers
- enable light/dark theme toggling with global toolbar
- create basic HomePage story

## Testing
- `npx eslint .storybook/preview.ts src/stories/decorators.tsx src/stories/AppHomePage.stories.tsx` *(fails: EslintPluginImportResolveError)*

------
https://chatgpt.com/codex/tasks/task_e_6849e11afa508324a7c4774f8d63fcd3