### PR TITLE
Reduce Fluent UI icon bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ yarn analyze
 ```
 
 This command uses `next-bundle-analyzer` and outputs a detailed report in `.next/analyze/webpack-stats.json`. Review the top modules to spot libraries that significantly impact bundle size.
+
+The configuration prefers the font-based variant of `@fluentui/react-icons` by setting `fluentIconFont` in Webpack's `conditionNames`. This avoids bundling thousands of SVG components and keeps the client bundle smaller.

--- a/next.config.js
+++ b/next.config.js
@@ -94,6 +94,12 @@ const nextConfig = {
   webpack: (config, options) => {
     const { dev, isServer } = options;
 
+    config.resolve = config.resolve || {};
+    config.resolve.conditionNames = [
+      'fluentIconFont',
+      ...(config.resolve.conditionNames || [])
+    ];
+
     if (!dev && !isServer) {
       config.plugins.push(
         new StatsWriterPlugin({


### PR DESCRIPTION
## Summary
- prioritize `fluentIconFont` in webpack `conditionNames`
- document the font variant for `@fluentui/react-icons`

## Testing
- `yarn test` *(fails: package missing in lockfile)*
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6849e0dbf7f08324bd7a9e85cd2ea894