### PR TITLE
Close drawer when performing a search

### DIFF
--- a/src/components/Toolbar/MobileDrawer/MobileDrawer.tsx
+++ b/src/components/Toolbar/MobileDrawer/MobileDrawer.tsx
@@ -49,7 +49,7 @@ const MobileDrawer: React.FC<MobileDrawerProps> = ({
       <DrawerBody className={styles.mobileMenu}>
         <div className={styles.drawerContentWrapper}>
           <div className={styles.searchWrapper}>
-            <SearchBar />
+            <SearchBar onSearch={() => onOpenChange(false)} />
           </div>
 
           <div className={styles.navSection}>

--- a/src/components/Toolbar/SearchBar/SearchBar.tsx
+++ b/src/components/Toolbar/SearchBar/SearchBar.tsx
@@ -9,7 +9,14 @@ import { useRouter } from "next/router";
 import { useSearchBox } from "../../../context";
 import { useDebounce } from "../../../hooks";
 
-export const SearchBar = () => {
+export type SearchBarProps = {
+  /**
+   * Optional callback fired when the user submits a search.
+   */
+  onSearch?: () => void;
+};
+
+export const SearchBar = ({ onSearch }: SearchBarProps) => {
   const { searchBoxValue = "", onSearchBoxValueChange } = useSearchBox();
 
   const [inputValue, setInputValue] = React.useState(searchBoxValue);
@@ -40,6 +47,7 @@ export const SearchBar = () => {
         // User is not on the home page, reroute
         await router.push(`/recipes`);
       }
+      onSearch?.();
     }
   };
 


### PR DESCRIPTION
## Summary
- add `onSearch` callback to `SearchBar`
- close the mobile drawer after submitting a search

## Testing
- `yarn tsc --noEmit`
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_685076048a788324bf077b577ac6481f