### PR TITLE
fix: Update Storybook API mocks for paginated responses

### DIFF
--- a/src/stories/decorators/withRecipeMocks.tsx
+++ b/src/stories/decorators/withRecipeMocks.tsx
@@ -84,25 +84,41 @@ export const generateManyPublicRecipes = () => [
 export const recipeVariants = {
   default: () => withApiMocks({
     '/api/recipes': {
-      response: baseRecipes,
+      response: {
+        recipes: baseRecipes,
+        totalCount: baseRecipes.length,
+        hasMore: false,
+      },
     },
   }),
 
   many: () => withApiMocks({
     '/api/recipes': {
-      response: generateManyRecipes(),
+      response: {
+        recipes: generateManyRecipes(),
+        totalCount: generateManyRecipes().length,
+        hasMore: false,
+      },
     },
   }),
 
   empty: () => withApiMocks({
     '/api/recipes': {
-      response: [],
+      response: {
+        recipes: [],
+        totalCount: 0,
+        hasMore: false,
+      },
     },
   }),
 
   loading: () => withApiMocks({
     '/api/recipes': {
-      response: baseRecipes,
+      response: {
+        recipes: baseRecipes,
+        totalCount: baseRecipes.length,
+        hasMore: false,
+      },
       delay: 999999,
     },
   }),
@@ -116,7 +132,11 @@ export const recipeVariants = {
 
   custom: (recipes: unknown[]) => withApiMocks({
     '/api/recipes': {
-      response: recipes,
+      response: {
+        recipes,
+        totalCount: recipes.length,
+        hasMore: false,
+      },
     },
   }),
 } as const;


### PR DESCRIPTION
## Summary
Fixed Storybook stories that were broken after the pagination feature was merged. The API response format changed but the Storybook mocks were still using the old format.

## Changes
- Updated all recipe mock variants in `withRecipeMocks.tsx` to return the new paginated format
- Changed from returning plain arrays to returning `{ recipes, totalCount, hasMore }`
- All Storybook stories now work correctly with the new API format

## Test Plan
- [x] Storybook builds successfully
- [x] RecipeGallery stories display recipes correctly
- [x] Many Recipes story shows all recipes
- [x] Empty state displays properly
- [x] Loading and error states work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)