### PR TITLE
Fix editor newline persistence and clear lint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -42,7 +42,7 @@ export default async () => {
     // Transform all node_modules except CSS modules and the few packages
     // that ship valid CJS (geist is required by next/jest).
     "^.+\\.module\\.(css|sass|scss)$",
-    "/node_modules/(?!(geist|string-width|strip-ansi|ansi-regex|wrap-ansi|jose|bson|mongodb|node-mocks-http|msw|@mswjs|rettime|until-async)/)",
+    "/node_modules/(?!(geist|string-width|strip-ansi|ansi-regex|wrap-ansi|jose|bson|mongodb|node-mocks-http|msw|@mswjs|@open-draft|rettime|until-async)/)",
   ];
   return config;
 };

--- a/jest.polyfills.js
+++ b/jest.polyfills.js
@@ -1,29 +1,61 @@
 // Polyfills for Jest/MSW compatibility
-const { TextDecoder, TextEncoder } = require("util");
+const { Blob, File } = require("buffer");
 const {
   ReadableStream,
   WritableStream,
   TransformStream,
 } = require("stream/web");
+const { TextDecoder, TextEncoder } = require("util");
 
-// Set global polyfills
-global.TextDecoder = TextDecoder;
-global.TextEncoder = TextEncoder;
-global.ReadableStream = ReadableStream;
-global.WritableStream = WritableStream;
-global.TransformStream = TransformStream;
+class MessagePort {
+  postMessage() {}
+  close() {}
+  start() {}
+  addEventListener() {}
+  removeEventListener() {}
+}
 
-// Mock BroadcastChannel for MSW
-global.BroadcastChannel = class BroadcastChannel {
-  constructor(name) {
-    this.name = name;
+class MessageChannel {
+  constructor() {
+    this.port1 = new MessagePort();
+    this.port2 = new MessagePort();
   }
+}
 
+Object.assign(global, {
+  Blob,
+  File,
+  MessageChannel,
+  MessagePort,
+  ReadableStream,
+  TextDecoder,
+  TextEncoder,
+  TransformStream,
+  WritableStream,
+});
+
+global.BroadcastChannel = class BroadcastChannel {
   postMessage() {}
   close() {}
   addEventListener() {}
   removeEventListener() {}
 };
+
+const {
+  fetch,
+  FormData,
+  Headers,
+  Request,
+  Response,
+} = require("undici");
+
+Object.assign(global, {
+  fetch,
+  FormData,
+  Headers,
+  Request,
+  Response,
+});
 
 // Mock window APIs for carousel library (only if window exists)
 if (typeof window !== "undefined") {
@@ -60,6 +92,3 @@ if (typeof window !== "undefined") {
     disconnect() {}
   };
 }
-
-// Import whatwg-fetch for fetch polyfill
-require("whatwg-fetch");

--- a/src/components/MealPlan/CalendarViews/HourlyDayView.tsx
+++ b/src/components/MealPlan/CalendarViews/HourlyDayView.tsx
@@ -64,7 +64,7 @@ export const HourlyDayView: React.FC<HourlyDayViewProps> = ({
     const legacyMealTypes = ["breakfast", "lunch", "dinner", "snack"] as const;
 
     legacyMealTypes.forEach((mealType) => {
-      const meal = dayPlan.meals[mealType as keyof typeof dayPlan.meals];
+      const meal = dayPlan.meals[mealType];
       if (
         meal &&
         typeof meal === "object" &&
@@ -78,7 +78,7 @@ export const HourlyDayView: React.FC<HourlyDayViewProps> = ({
             {
               ...meal,
               time: defaultTime,
-            } as MealItem & { recipe?: Record<string, unknown> },
+            },
           ]);
         }
       }

--- a/src/components/MealPlan/hooks/useMealDragDrop.ts
+++ b/src/components/MealPlan/hooks/useMealDragDrop.ts
@@ -3,8 +3,6 @@ import type { DragEndEvent } from "@dnd-kit/core";
 
 import type { DraggedRecipe, MealDragDropHandlers } from "../types";
 
-import type { CreateMealPlanPayload } from "../../../clientToServer/types";
-
 export function useMealDragDrop(handlers: MealDragDropHandlers, view: string) {
   const [draggedRecipe, setDraggedRecipe] = useState<DraggedRecipe | null>(
     null,
@@ -105,10 +103,10 @@ export function useMealDragDrop(handlers: MealDragDropHandlers, view: string) {
         // If we have a specific time slot, use it directly
         if (dropTarget.time) {
           handlers.addMealMutation.mutate({
-            date: dropTarget.date as string,
+            date: dropTarget.date,
             recipeId: recipe.id,
             servings: 1,
-            time: dropTarget.time as string,
+            time: dropTarget.time,
             duration: 60,
           });
         }
@@ -119,19 +117,19 @@ export function useMealDragDrop(handlers: MealDragDropHandlers, view: string) {
           view === "week" ||
           view === "month"
         ) {
-          handlers.setPendingMeal({ recipe, date: dropTarget.date as string });
+          handlers.setPendingMeal({ recipe, date: dropTarget.date });
           handlers.setShowTimePicker(true);
           handlers.setSidebarOpen(false);
         }
         // Legacy meal type support
         else if (dropTarget.mealType) {
           handlers.addMealMutation.mutate({
-            date: dropTarget.date as string,
+            date: dropTarget.date,
             recipeId: recipe.id,
             servings: 1,
             time: "",
             mealType: dropTarget.mealType,
-          } as CreateMealPlanPayload);
+          });
         }
       }
 

--- a/src/components/MealPlan/utils/getMealsForDate.ts
+++ b/src/components/MealPlan/utils/getMealsForDate.ts
@@ -4,10 +4,7 @@
 import { formatDateString } from "./formatDateString";
 import type { TimeSlot } from "../types";
 
-import type {
-  MealPlanWithRecipes,
-  MealItem,
-} from "../../../clientToServer/types";
+import type { MealPlanWithRecipes } from "../../../clientToServer/types";
 import { mealTypeToTime } from "../../../utils/timeSlots";
 
 export const getMealsForDate = (
@@ -36,13 +33,11 @@ export const getMealsForDate = (
       const existingSlot = allSlots.find((slot) => slot.time === time);
 
       if (existingSlot) {
-        existingSlot.meals.push(
-          meal as MealItem & { recipe?: Record<string, unknown> },
-        );
+        existingSlot.meals.push(meal);
       } else {
         allSlots.push({
           time,
-          meals: [meal as MealItem & { recipe?: Record<string, unknown> }],
+          meals: [meal],
         });
       }
     }

--- a/src/components/MealPlan/utils/getScheduledMealsForDate.ts
+++ b/src/components/MealPlan/utils/getScheduledMealsForDate.ts
@@ -35,7 +35,7 @@ export const getScheduledMealsForDate = (
   const legacyMealTypes = ["breakfast", "lunch", "dinner", "snack"] as const;
 
   legacyMealTypes.forEach((mealType) => {
-    const meal = dayPlan.meals[mealType as keyof typeof dayPlan.meals];
+    const meal = dayPlan.meals[mealType];
     if (
       meal &&
       typeof meal === "object" &&
@@ -46,13 +46,11 @@ export const getScheduledMealsForDate = (
       // Check if we already have a time slot for this time
       const existingSlot = scheduledMeals.find((slot) => slot.time === time);
       if (existingSlot) {
-        existingSlot.meals.push(
-          meal as MealItem & { recipe?: Record<string, unknown> },
-        );
+        existingSlot.meals.push(meal);
       } else {
         scheduledMeals.push({
           time,
-          meals: [meal as MealItem & { recipe?: Record<string, unknown> }],
+          meals: [meal],
         });
       }
     }

--- a/src/components/MealPlan/utils/optimisticUpdates.ts
+++ b/src/components/MealPlan/utils/optimisticUpdates.ts
@@ -4,7 +4,6 @@
 import type {
   CreateMealPlanPayload,
   MealPlanWithRecipes,
-  MealType,
 } from "../../../clientToServer/types";
 import { mealTypeToTime } from "../../../utils/timeSlots";
 
@@ -60,19 +59,17 @@ export function addMealOptimistically(
       }
     } else if (mealType) {
       // Legacy meal type
-      const legacyKey = mealType as MealType;
-      const legacyMealTypes: MealType[] = [
-        "breakfast",
-        "lunch",
-        "dinner",
-        "snack",
-      ];
-      if (!legacyMealTypes.includes(legacyKey)) {
+      if (
+        mealType !== "breakfast" &&
+        mealType !== "lunch" &&
+        mealType !== "dinner" &&
+        mealType !== "snack"
+      ) {
         return plan;
       }
       const meals = { ...updatedPlan.meals };
-      const defaultTime = time ?? mealTypeToTime(legacyKey);
-      meals[legacyKey] = {
+      const defaultTime = time ?? mealTypeToTime(mealType);
+      meals[mealType] = {
         recipeId: newMeal.recipeId ?? "",
         servings: newMeal.servings ?? 1,
         time: defaultTime,

--- a/src/components/RecipeGallery/RecipeGallery.tsx
+++ b/src/components/RecipeGallery/RecipeGallery.tsx
@@ -158,7 +158,7 @@ export const RecipeGallery: React.FC<RecipeGalleryProps> = ({
           currentPage={currentPage}
           pageSize={pageSize}
           isLoading={isLoading}
-          error={error as Error}
+          error={error}
           onPageChange={handlePageChange}
           onPageSizeChange={() => {}}
           emptyStateMessage="No recipes found in your collection."

--- a/src/components/RecipePage/RecipePage.tsx
+++ b/src/components/RecipePage/RecipePage.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { useRef, useState } from "react";
-import { $convertToMarkdownString } from "@lexical/markdown";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { LexicalEditor } from "lexical";
 import { useRouter } from "next/router";
@@ -13,7 +12,7 @@ import {
   RecipeViewSaveStateProvider,
   useRecipeViewSaveState,
 } from "../RecipeView/RecipeViewSaveStateContext";
-import { recipeTransformers } from "../TextEditor/textEditorConfig";
+import { exportRecipeMarkdown } from "../TextEditor/textEditorConfig";
 
 import { fetchRecipe } from "../../clientToServer";
 
@@ -74,9 +73,7 @@ function RecipePageInner({ recipeId, onCancelReset }: RecipePageInnerProps) {
     if (!editor) {
       return;
     }
-    const data = editor.read(() =>
-      $convertToMarkdownString(recipeTransformers),
-    );
+    const data = editor.read(exportRecipeMarkdown);
     const title = saveState?.getTitle() ?? recipe.title;
     const emoji = saveState?.getEmoji() ?? recipe.emoji;
     const tags = saveState?.getTags() ?? recipe.tags ?? [];

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -77,7 +77,7 @@ export const Text = React.forwardRef<HTMLElement, TextProps>(
 
     return (
       <Component
-        ref={ref as React.Ref<HTMLElement>}
+        ref={ref}
         className={classNames}
         {...rest}
       >

--- a/src/components/TextEditor/TextEditor.tsx
+++ b/src/components/TextEditor/TextEditor.tsx
@@ -1,21 +1,16 @@
 import { useEffect, useRef } from "react";
 import type { MutableRefObject } from "react";
-import { ListNode, ListItemNode } from "@lexical/list";
-import { $convertFromMarkdownString } from "@lexical/markdown";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
-import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
 import { HorizontalRulePlugin } from "@lexical/react/LexicalHorizontalRulePlugin";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { TablePlugin } from "@lexical/react/LexicalTablePlugin";
-import { HeadingNode, QuoteNode } from "@lexical/rich-text";
-import { TableNode, TableCellNode, TableRowNode } from "@lexical/table";
 import type { LexicalEditor } from "lexical";
 
 import { SelectAllPlugin, MarkdownPastePlugin } from "./plugins";
@@ -23,9 +18,10 @@ import styles from "./TextEditor.module.css";
 import type { TextEditorProps } from "./TextEditor.types";
 import {
   editorTheme,
-  recipeTransformers,
-  recipeShortcutTransformers,
   hashMarkdownKey,
+  importRecipeMarkdown,
+  recipeEditorNodes,
+  recipeShortcutTransformers,
 } from "./textEditorConfig";
 import { TextEditorPlaceholder } from "./TextEditorPlaceholder/TextEditorPlaceholder";
 import { SlashMenu } from "./TextEditorSlashMenu/TextEditorSlashMenu";
@@ -57,20 +53,11 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
 
   const initialConfig = {
     namespace: "RecipeEditor",
-    nodes: [
-      HeadingNode,
-      QuoteNode,
-      ListNode,
-      ListItemNode,
-      HorizontalRuleNode,
-      TableNode,
-      TableCellNode,
-      TableRowNode,
-    ],
+    nodes: recipeEditorNodes,
     theme: editorTheme,
     editable: isEditable,
     editorState: () => {
-      $convertFromMarkdownString(text, recipeTransformers, undefined, true);
+      importRecipeMarkdown(text);
     },
     onError: (error: Error) => console.error(error),
   };

--- a/src/components/TextEditor/plugins/MarkdownPastePlugin.ts
+++ b/src/components/TextEditor/plugins/MarkdownPastePlugin.ts
@@ -1,9 +1,8 @@
 import { useEffect } from "react";
-import { $convertFromMarkdownString } from "@lexical/markdown";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $getRoot, $getSelection, $isRangeSelection } from "lexical";
 
-import { recipeTransformers } from "../textEditorConfig";
+import { importRecipeMarkdown } from "../textEditorConfig";
 
 function looksLikeMarkdown(text: string): boolean {
   return /^#{1,6}\s|\*\*|__|\*[^*]|^-\s|^\d+\.\s|^>\s|^```/m.test(text);
@@ -36,7 +35,7 @@ export function MarkdownPastePlugin() {
             selection.getTextContent().trim() === rootText);
 
         if (isEmptyOrFullySelected) {
-          $convertFromMarkdownString(text, recipeTransformers, undefined, true);
+          importRecipeMarkdown(text);
         } else if ($isRangeSelection(selection)) {
           selection.insertText(text);
         }

--- a/src/components/TextEditor/textEditorConfig.test.ts
+++ b/src/components/TextEditor/textEditorConfig.test.ts
@@ -1,0 +1,44 @@
+import { createEditor } from "lexical";
+
+import {
+  exportRecipeMarkdown,
+  importRecipeMarkdown,
+  recipeEditorNodes,
+} from "./textEditorConfig";
+
+const roundTripMarkdown = (markdown: string): string => {
+  const editor = createEditor({
+    namespace: "RecipeEditorTest",
+    nodes: recipeEditorNodes,
+    onError: (error: Error) => {
+      throw error;
+    },
+  });
+
+  editor.update(() => importRecipeMarkdown(markdown), { discrete: true });
+
+  return editor.read(exportRecipeMarkdown);
+};
+
+describe("recipe markdown serialization", () => {
+  it.each([
+    ["adjacent lines", "First line\nSecond line"],
+    ["intentional blank lines", "First paragraph\n\nSecond paragraph"],
+    ["multiple blank lines", "First paragraph\n\n\nSecond paragraph"],
+    [
+      "structured recipe content",
+      "# Ingredients\n- 1 cup flour\n- 2 eggs\n\n# Method\n1. Mix ingredients\n2. Bake",
+    ],
+  ])("preserves %s", (_description, markdown) => {
+    expect(roundTripMarkdown(markdown)).toBe(markdown);
+  });
+
+  it("does not add blank lines over repeated saves", () => {
+    const markdown = "First line\nSecond line\nThird line";
+    const firstSave = roundTripMarkdown(markdown);
+    const secondSave = roundTripMarkdown(firstSave);
+
+    expect(firstSave).toBe(markdown);
+    expect(secondSave).toBe(markdown);
+  });
+});

--- a/src/components/TextEditor/textEditorConfig.ts
+++ b/src/components/TextEditor/textEditorConfig.ts
@@ -1,14 +1,31 @@
+import { ListItemNode, ListNode } from "@lexical/list";
 import {
+  $convertFromMarkdownString,
+  $convertToMarkdownString,
   HEADING,
+  ORDERED_LIST,
   QUOTE,
   TEXT_FORMAT_TRANSFORMERS,
-  ORDERED_LIST,
   UNORDERED_LIST,
 } from "@lexical/markdown";
+import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
+import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
 
 import { HR_TRANSFORMER, TABLE_TRANSFORMER } from "./markdownExtensions";
 import styles from "./TextEditor.module.css";
 import typography from "../Typography/Typography.module.css";
+
+export const recipeEditorNodes = [
+  HeadingNode,
+  QuoteNode,
+  ListNode,
+  ListItemNode,
+  HorizontalRuleNode,
+  TableNode,
+  TableCellNode,
+  TableRowNode,
+];
 
 export const editorTheme = {
   paragraph: typography.bodyText,
@@ -58,7 +75,14 @@ export const recipeShortcutTransformers = [
   ...TEXT_FORMAT_TRANSFORMERS,
 ];
 
-export const hashMarkdownKey = (markdown: string) => {
+export const importRecipeMarkdown = (markdown: string): void => {
+  $convertFromMarkdownString(markdown, recipeTransformers, undefined, true);
+};
+
+export const exportRecipeMarkdown = (): string =>
+  $convertToMarkdownString(recipeTransformers, undefined, true);
+
+export const hashMarkdownKey = (markdown: string): string => {
   const len = markdown.length;
   const sample =
     len > 8000

--- a/src/pages/api/meal-plans/[date]/[time]/[mealIndex].ts
+++ b/src/pages/api/meal-plans/[date]/[time]/[mealIndex].ts
@@ -29,13 +29,19 @@ export default async function handler(
   try {
     const { date, time, mealIndex } = req.query;
 
-    if (!date || !time || mealIndex === undefined) {
+    if (
+      typeof date !== "string" ||
+      date.length === 0 ||
+      typeof time !== "string" ||
+      time.length === 0 ||
+      typeof mealIndex !== "string"
+    ) {
       return res.status(400).json({
         message: "Date, time, and meal index are required",
       });
     }
 
-    const mealIndexNum = parseInt(mealIndex as string, 10);
+    const mealIndexNum = parseInt(mealIndex, 10);
     if (isNaN(mealIndexNum) || mealIndexNum < 0) {
       return res.status(400).json({
         message: "Invalid meal index",
@@ -47,7 +53,7 @@ export default async function handler(
     // Find the meal plan
     const mealPlan = await db.collection("mealPlans").findOne({
       userId: session.user.id,
-      date: date as string,
+      date,
     });
 
     if (!mealPlan) {
@@ -79,13 +85,13 @@ export default async function handler(
     if (timeSlot.meals.length === 1) {
       // Remove the entire time slot if it's the only meal
       const removeTimeSlotUpdate = {
-        $pull: { "meals.timeSlots": { time: time as string } },
+        $pull: { "meals.timeSlots": { time } },
         $set: { updatedAt: new Date() },
       } as unknown as UpdateFilter<Document>;
       await db.collection("mealPlans").updateOne(
         {
           userId: session.user.id,
-          date: date as string,
+          date,
         },
         removeTimeSlotUpdate,
       );
@@ -94,7 +100,7 @@ export default async function handler(
       await db.collection("mealPlans").updateOne(
         {
           userId: session.user.id,
-          date: date as string,
+          date,
         },
         {
           $unset: {
@@ -111,7 +117,7 @@ export default async function handler(
       await db.collection("mealPlans").updateOne(
         {
           userId: session.user.id,
-          date: date as string,
+          date,
         },
         cleanUpMealsUpdate,
       );

--- a/src/pages/api/meal-plans/[date]/[time]/move.ts
+++ b/src/pages/api/meal-plans/[date]/[time]/move.ts
@@ -22,11 +22,15 @@ export default async function handler(
     const { mealIndex, targetDate, targetTime } = req.body;
 
     if (
-      !date ||
-      !time ||
+      typeof date !== "string" ||
+      date.length === 0 ||
+      typeof time !== "string" ||
+      time.length === 0 ||
       typeof mealIndex !== "number" ||
-      !targetDate ||
-      !targetTime
+      typeof targetDate !== "string" ||
+      targetDate.length === 0 ||
+      typeof targetTime !== "string" ||
+      targetTime.length === 0
     ) {
       return res.status(400).json({ message: "Missing required parameters" });
     }
@@ -37,7 +41,7 @@ export default async function handler(
     // Find the source meal plan
     const sourceMealPlan = await mealPlansCollection.findOne({
       userId: session.user.id,
-      date: date as string,
+      date,
     });
 
     if (!sourceMealPlan) {
@@ -98,7 +102,7 @@ export default async function handler(
 
       // Update the meal plan
       await mealPlansCollection.updateOne(
-        { userId: session.user.id, date: date as string },
+        { userId: session.user.id, date },
         {
           $set: {
             "meals.timeSlots": timeSlots,
@@ -121,7 +125,7 @@ export default async function handler(
 
     // Update source meal plan
     await mealPlansCollection.updateOne(
-      { userId: session.user.id, date: date as string },
+      { userId: session.user.id, date },
       {
         $set: {
           "meals.timeSlots": timeSlots,
@@ -131,7 +135,7 @@ export default async function handler(
     );
 
     // Now add to target meal plan
-    const targetDateStr = targetDate as string;
+    const targetDateStr = targetDate;
 
     // Find or create target meal plan
     let targetMealPlan = await mealPlansCollection.findOne({

--- a/src/pages/api/meal-plans/[date]/[time]/reorder.ts
+++ b/src/pages/api/meal-plans/[date]/[time]/reorder.ts
@@ -22,8 +22,10 @@ export default async function handler(
     const { oldIndex, newIndex } = req.body;
 
     if (
-      !date ||
-      !time ||
+      typeof date !== "string" ||
+      date.length === 0 ||
+      typeof time !== "string" ||
+      time.length === 0 ||
       typeof oldIndex !== "number" ||
       typeof newIndex !== "number"
     ) {
@@ -36,7 +38,7 @@ export default async function handler(
     // Find the meal plan for this date
     const mealPlan = await mealPlansCollection.findOne({
       userId: session.user.id,
-      date: date as string,
+      date,
     });
 
     if (!mealPlan) {
@@ -72,7 +74,7 @@ export default async function handler(
 
     // Update the meal plan
     const result = await mealPlansCollection.updateOne(
-      { userId: session.user.id, date: date as string },
+      { userId: session.user.id, date },
       {
         $set: {
           "meals.timeSlots": timeSlots,

--- a/src/pages/api/meal-plans/calendar.ics.ts
+++ b/src/pages/api/meal-plans/calendar.ics.ts
@@ -25,6 +25,12 @@ type RecipeDocument = {
   emoji?: string;
   imageURL?: string;
 };
+const legacyMealKeys: LegacyMealKey[] = [
+  "breakfast",
+  "lunch",
+  "dinner",
+  "snack",
+];
 
 const isMealItem = (meal: unknown): meal is MealItem =>
   typeof meal === "object" &&
@@ -165,14 +171,13 @@ export default async function handler(
         }));
       }
 
-      const { timeSlots: _timeSlots, ...legacyMeals } = meals;
-      Object.entries(legacyMeals).forEach(([mealType, meal]) => {
+      legacyMealKeys.forEach((key) => {
+        const meal = meals[key];
         if (isMealItem(meal)) {
-          const key = mealType as LegacyMealKey;
           enhancedMeals[key] = {
             ...meal,
             ...(meal.recipeId ? { recipe: recipeMap.get(meal.recipeId) } : {}),
-          } as MealPlanWithRecipes["meals"][LegacyMealKey];
+          };
         }
       });
 

--- a/src/pages/api/meal-plans/index.ts
+++ b/src/pages/api/meal-plans/index.ts
@@ -97,7 +97,7 @@ async function handleGet(
                 if (mealData?.recipeId) {
                   return {
                     ...mealData,
-                    recipe: recipeMap.get(mealData.recipeId as string) ?? null,
+                    recipe: recipeMap.get(mealData.recipeId) ?? null,
                   };
                 }
                 return mealData;
@@ -120,7 +120,7 @@ async function handleGet(
           if (mealData?.recipeId) {
             enhancedMeals[mealType] = {
               ...mealData,
-              recipe: recipeMap.get(mealData.recipeId as string) ?? null,
+              recipe: recipeMap.get(mealData.recipeId) ?? null,
             };
           } else {
             enhancedMeals[mealType] = mealData;

--- a/src/server/ai/model.ts
+++ b/src/server/ai/model.ts
@@ -10,7 +10,16 @@ import type { LanguageModel } from "ai";
 export function getAiModel(): LanguageModel {
   const provider = process.env.AI_PROVIDER?.toLowerCase() ?? "openai";
 
-  const providers = {
+  const getGoogleModel = () => {
+    const apiKey = process?.env?.GEMINI_API_KEY;
+    if (!apiKey) {
+      throw new Error("GEMINI_API_KEY environment variable is not set.");
+    }
+    const modelName = process?.env?.GEMINI_MODEL ?? "gemini-1.5-flash";
+    return createGoogleGenerativeAI({ apiKey })(modelName);
+  };
+
+  const providers: Record<string, () => LanguageModel> = {
     openai: () => {
       const apiKey = process?.env?.OPENAI_API_KEY;
       if (!apiKey) {
@@ -19,21 +28,15 @@ export function getAiModel(): LanguageModel {
       const modelName = process?.env?.OPENAI_MODEL ?? "gpt-4o";
       return createOpenAI({ apiKey })(modelName);
     },
-    google: () => {
-      const apiKey = process?.env?.GEMINI_API_KEY;
-      if (!apiKey) {
-        throw new Error("GEMINI_API_KEY environment variable is not set.");
-      }
-      const modelName = process?.env?.GEMINI_MODEL ?? "gemini-1.5-flash";
-      return createGoogleGenerativeAI({ apiKey })(modelName);
-    },
-    gemini() {
-      return this.google();
-    },
+    google: getGoogleModel,
+    gemini: getGoogleModel,
   };
 
   try {
-    const getModel = providers[provider as keyof typeof providers];
+    const getModel = providers[provider];
+    if (!getModel) {
+      throw new Error(`Unsupported AI_PROVIDER: ${provider}`);
+    }
     return getModel();
   } catch (error) {
     console.error("[AI Model] Configuration failed:", error);

--- a/src/stories/mockApi.tsx
+++ b/src/stories/mockApi.tsx
@@ -49,7 +49,7 @@ export const defaultMocks: ApiMockConfig = {
 };
 
 const createFetchMock = (mockConfig: ApiMockConfig) => {
-  const originalFetch = window.fetch;
+  const originalFetch = window.fetch.bind(window);
 
   window.fetch = async (url: string | Request | URL, options?: RequestInit) => {
     const urlString =


### PR DESCRIPTION
## Summary
- preserve intentional Lexical newlines across edit/save round trips
- add newline regression coverage and repair Jest/MSW fetch polyfills
- resolve all repository ESLint errors and warnings without suppressions

## Validation
- `npm run lint` — no warnings or errors
- `npm test -- --runInBand --no-cache` — 38 suites passed, 316 tests passed, 1 skipped
- `npm run build` — succeeded
- isolated Chromium/CDP editor flow — two save cycles preserved `Alpha\nBeta\n\nGamma` exactly, with no console errors, page errors, or failed requests
- independent code review — no remaining high-confidence findings

## Environment note
The browser validation mocked auth and recipe APIs in an isolated Chromium context because local auth environment variables are not configured.