### PR TITLE
fix(editor): preserve line breaks and structure when pasting markdown

### DIFF
--- a/src/components/TextEditor/plugins/MarkdownPastePlugin.ts
+++ b/src/components/TextEditor/plugins/MarkdownPastePlugin.ts
@@ -1,24 +1,29 @@
 import { useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { $getRoot, $getSelection, $isRangeSelection } from "lexical";
 
-import { importRecipeMarkdown } from "../textEditorConfig";
-
-function looksLikeMarkdown(text: string): boolean {
-  return /^#{1,6}\s|\*\*|__|\*[^*]|^-\s|^\d+\.\s|^>\s|^```/m.test(text);
-}
+import {
+  $insertPastedMarkdown,
+  LEXICAL_CLIPBOARD_TYPE,
+  looksLikeMarkdown,
+} from "./pasteMarkdown";
 
 export function MarkdownPastePlugin() {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    const root = editor.getRootElement();
-    if (!root) {
-      return;
-    }
-
     const handler = (event: ClipboardEvent) => {
-      const text = event.clipboardData?.getData("text/plain");
+      const clipboardData = event.clipboardData;
+      if (!clipboardData) {
+        return;
+      }
+
+      // Copies made inside a Lexical editor carry full node data — let Lexical
+      // restore it rather than degrading it to markdown text.
+      if (Array.from(clipboardData.types).includes(LEXICAL_CLIPBOARD_TYPE)) {
+        return;
+      }
+
+      const text = clipboardData.getData("text/plain");
       if (!text || !looksLikeMarkdown(text)) {
         return;
       }
@@ -26,24 +31,13 @@ export function MarkdownPastePlugin() {
       event.preventDefault();
       event.stopPropagation();
 
-      editor.update(() => {
-        const selection = $getSelection();
-        const rootText = $getRoot().getTextContent().trim();
-        const isEmptyOrFullySelected =
-          rootText === "" ||
-          ($isRangeSelection(selection) &&
-            selection.getTextContent().trim() === rootText);
-
-        if (isEmptyOrFullySelected) {
-          importRecipeMarkdown(text);
-        } else if ($isRangeSelection(selection)) {
-          selection.insertText(text);
-        }
-      });
+      editor.update(() => $insertPastedMarkdown(text));
     };
 
-    root.addEventListener("paste", handler, true); // capture phase
-    return () => root.removeEventListener("paste", handler, true);
+    return editor.registerRootListener((rootElement, prevRootElement) => {
+      prevRootElement?.removeEventListener("paste", handler, true);
+      rootElement?.addEventListener("paste", handler, true); // capture phase
+    });
   }, [editor]);
 
   return null;

--- a/src/components/TextEditor/plugins/pasteMarkdown.test.ts
+++ b/src/components/TextEditor/plugins/pasteMarkdown.test.ts
@@ -1,0 +1,129 @@
+import { $getRoot, createEditor } from "lexical";
+import type { LexicalEditor } from "lexical";
+
+import { $insertPastedMarkdown, looksLikeMarkdown } from "./pasteMarkdown";
+import {
+  exportRecipeMarkdown,
+  importRecipeMarkdown,
+  recipeEditorNodes,
+} from "../textEditorConfig";
+
+const createRecipeEditor = (initialMarkdown: string): LexicalEditor => {
+  const editor = createEditor({
+    namespace: "RecipePasteTest",
+    nodes: recipeEditorNodes,
+    onError: (error: Error) => {
+      throw error;
+    },
+  });
+
+  editor.update(() => importRecipeMarkdown(initialMarkdown), {
+    discrete: true,
+  });
+
+  return editor;
+};
+
+const pasteAtEnd = (initialMarkdown: string, pasted: string): string => {
+  const editor = createRecipeEditor(initialMarkdown);
+
+  editor.update(
+    () => {
+      $getRoot().getLastDescendant()?.selectEnd();
+      $insertPastedMarkdown(pasted);
+    },
+    { discrete: true }
+  );
+
+  return editor.read(exportRecipeMarkdown);
+};
+
+describe("looksLikeMarkdown", () => {
+  it.each([
+    ["heading", "# Ingredients"],
+    ["bullet list", "- 2 eggs"],
+    ["ordered list", "1. Mix"],
+    ["quote", "> Rest overnight"],
+    ["bold", "Add **salt**"],
+    ["table", "| a | b |"],
+  ])("detects %s", (_description, text) => {
+    expect(looksLikeMarkdown(text)).toBe(true);
+  });
+
+  it("ignores plain prose", () => {
+    expect(looksLikeMarkdown("Preheat the oven\nThen bake it")).toBe(false);
+  });
+});
+
+describe("pasting markdown into a populated editor", () => {
+  it("keeps pasted line breaks instead of collapsing them into one text node", () => {
+    const editor = createRecipeEditor("# Recipe\nExisting line");
+
+    editor.update(
+      () => {
+        $getRoot().getLastDescendant()?.selectEnd();
+        $insertPastedMarkdown("- eggs\n- flour");
+      },
+      { discrete: true }
+    );
+
+    const textNodesWithNewlines = editor.read(() =>
+      $getRoot()
+        .getAllTextNodes()
+        .filter((node) => node.getTextContent().includes("\n"))
+    );
+
+    expect(textNodesWithNewlines).toHaveLength(0);
+  });
+
+  it("converts a pasted bullet list into real list nodes", () => {
+    const editor = createRecipeEditor("# Recipe\nExisting line");
+
+    editor.update(
+      () => {
+        $getRoot().getLastDescendant()?.selectEnd();
+        $insertPastedMarkdown("- eggs\n- flour");
+      },
+      { discrete: true }
+    );
+
+    const listCount = editor.read(
+      () =>
+        $getRoot()
+          .getChildren()
+          .filter((node) => node.getType() === "list").length
+    );
+
+    expect(listCount).toBe(1);
+  });
+
+  it("preserves headings and adjacent lines from pasted markdown", () => {
+    const result = pasteAtEnd(
+      "# Recipe",
+      "## Ingredients\n- eggs\n- flour\n\n## Method\n1. Mix\n2. Bake"
+    );
+
+    expect(result).toContain("## Ingredients");
+    expect(result).toContain("- eggs\n- flour");
+    expect(result).toContain("1. Mix\n2. Bake");
+  });
+
+  it("replaces the document when the editor is empty", () => {
+    const result = pasteAtEnd("", "# Recipe\nFirst line\nSecond line");
+
+    expect(result).toBe("# Recipe\nFirst line\nSecond line");
+  });
+
+  it("merges a single pasted paragraph inline instead of starting a new block", () => {
+    const result = pasteAtEnd("Add the **salt**", " and pepper");
+
+    expect(result).toBe("Add the **salt** and pepper");
+  });
+
+  it("does not gain blank lines when pasted content is saved and reloaded", () => {    const firstSave = pasteAtEnd("# Recipe\nExisting line", "- eggs\n- flour");
+    const editor = createRecipeEditor(firstSave);
+    const secondSave = editor.read(exportRecipeMarkdown);
+
+    expect(secondSave).toBe(firstSave);
+  });
+});

--- a/src/components/TextEditor/plugins/pasteMarkdown.ts
+++ b/src/components/TextEditor/plugins/pasteMarkdown.ts
@@ -1,0 +1,80 @@
+import {
+  $createParagraphNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $isParagraphNode,
+  $setSelection,
+} from "lexical";
+import type { LexicalNode } from "lexical";
+
+import { importRecipeMarkdown } from "../textEditorConfig";
+
+/** Clipboard flavour Lexical writes when copying from inside an editor. */
+export const LEXICAL_CLIPBOARD_TYPE = "application/x-lexical-editor";
+
+const MARKDOWN_PATTERN =
+  /^#{1,6}\s|\*\*|__|\*[^*]|^-\s|^\d+\.\s|^>\s|^```|^\|.*\|/m;
+
+export function looksLikeMarkdown(text: string): boolean {
+  return MARKDOWN_PATTERN.test(text);
+}
+
+/**
+ * Converts markdown into detached block nodes.
+ *
+ * The markdown importer clears its target container and moves the selection to
+ * it, so the caller's selection is saved and restored around the conversion.
+ */
+export function $markdownToNodes(markdown: string): LexicalNode[] {
+  const savedSelection = $getSelection()?.clone() ?? null;
+  const container = $createParagraphNode();
+
+  importRecipeMarkdown(markdown, container);
+  const nodes = container.getChildren();
+
+  $setSelection(savedSelection);
+  return nodes;
+}
+
+/**
+ * Inserts pasted markdown at the current selection.
+ *
+ * An empty or fully selected document is replaced outright; otherwise the
+ * markdown is converted to real block nodes and spliced in at the caret so
+ * line breaks, lists and headings survive the paste.
+ */
+export function $insertPastedMarkdown(markdown: string): void {
+  const selection = $getSelection();
+  const rootText = $getRoot().getTextContent().trim();
+  const isEmptyOrFullySelected =
+    rootText === "" ||
+    ($isRangeSelection(selection) &&
+      selection.getTextContent().trim() === rootText);
+
+  if (isEmptyOrFullySelected) {
+    importRecipeMarkdown(markdown);
+    return;
+  }
+
+  if (!$isRangeSelection(selection)) {
+    return;
+  }
+
+  const nodes = $markdownToNodes(markdown);
+  if (nodes.length === 0) {
+    return;
+  }
+
+  // Lexical merges the first inserted block into the block holding the caret.
+  // Leading a block-level paste with an empty paragraph keeps a pasted heading,
+  // list or quote from being absorbed into the current line.
+  if (!$isParagraphNode(nodes[0])) {
+    nodes.unshift($createParagraphNode());
+  }
+
+  const currentSelection = $getSelection();
+  if ($isRangeSelection(currentSelection)) {
+    currentSelection.insertNodes(nodes);
+  }
+}

--- a/src/components/TextEditor/textEditorConfig.ts
+++ b/src/components/TextEditor/textEditorConfig.ts
@@ -11,6 +11,7 @@ import {
 import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
+import type { ElementNode } from "lexical";
 
 import { HR_TRANSFORMER, TABLE_TRANSFORMER } from "./markdownExtensions";
 import styles from "./TextEditor.module.css";
@@ -75,8 +76,11 @@ export const recipeShortcutTransformers = [
   ...TEXT_FORMAT_TRANSFORMERS,
 ];
 
-export const importRecipeMarkdown = (markdown: string): void => {
-  $convertFromMarkdownString(markdown, recipeTransformers, undefined, true);
+export const importRecipeMarkdown = (
+  markdown: string,
+  node?: ElementNode
+): void => {
+  $convertFromMarkdownString(markdown, recipeTransformers, node, true);
 };
 
 export const exportRecipeMarkdown = (): string =>


### PR DESCRIPTION
## Problem

Pasting markdown into a **populated** recipe editor lost all line breaks and block structure. `MarkdownPastePlugin` only converted markdown when the document was empty or fully selected; otherwise it fell back to `RangeSelection.insertText(rawText)`, which writes the whole clipboard string into a single `TextNode`. Line breaks became literal `\n` characters collapsed onto one line, and `#` / `-` / `1.` stayed as visible plain text until a save + reload re-parsed it.

Two related defects surfaced while tracing it:

- Copies made *inside* the editor carry `application/x-lexical-editor` node data, but the handler downgraded them to markdown-looking plain text.
- The listener was attached from a one-shot `editor.getRootElement()` read, so it would not survive a root element remount.

## Fix

- New `plugins/pasteMarkdown.ts`. `` imports markdown into a *detached* paragraph container and saves/restores the caret, since the markdown importer calls `selectStart()`. `` splices real block nodes in with `insertNodes`, prefixing an empty paragraph when the first converted node is not a paragraph so a pasted heading is not absorbed into the block holding the caret.
- `importRecipeMarkdown` now accepts an optional `ElementNode` container, keeping one newline policy shared by load, paste and save.
- `MarkdownPastePlugin` defers to Lexical for its own clipboard flavour and attaches via `registerRootListener`.

No new dependencies.

## Validation

- 12 new unit tests; 18 across TextEditor; **329 passed / 40 suites** repo-wide.
- `npm run lint`: no warnings or errors.
- `npm run build`: exit 0.
- Chromium paste into a populated editor produced `H2 -> UL(2) -> H2 -> OL(2)`, **0 text nodes containing raw newlines**, 0 console or page errors.