### PR TITLE
feat(recipe): protect unsaved recipe edits from being silently lost

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import type { Preview } from "@storybook/nextjs";
 import { withGlobalProviders } from "../src/stories/globalProviders";
 import { MOCK_BASE_DATE } from "../src/mocks/utils/mockDates";
+import "../src/styles/global.css";
 
 // Mock Date globally for consistent Chromatic snapshots
 // This ensures all stories use the same fixed date

--- a/src/components/ConfirmDialog/ConfirmDialog.test.tsx
+++ b/src/components/ConfirmDialog/ConfirmDialog.test.tsx
@@ -1,0 +1,99 @@
+import userEvent from "@testing-library/user-event";
+
+import { ConfirmDialog } from "./ConfirmDialog";
+
+import { render, screen } from "../../utils/testing/TestUtils";
+
+const setup = (overrides: Partial<Parameters<typeof ConfirmDialog>[0]> = {}) => {
+  const onConfirm = jest.fn();
+  const onCancel = jest.fn();
+  const onOpenChange = jest.fn();
+
+  render(
+    <ConfirmDialog
+      open
+      onOpenChange={onOpenChange}
+      title="Discard unsaved changes?"
+      description="Your edits will be lost if you continue."
+      confirmLabel="Discard changes"
+      cancelLabel="Keep editing"
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      {...overrides}
+    />
+  );
+
+  return { onConfirm, onCancel, onOpenChange };
+};
+
+describe("ConfirmDialog", () => {
+  it("announces itself as an alert dialog with its title and description", () => {
+    setup();
+
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toBeInTheDocument();
+    expect(
+      screen.getByText("Discard unsaved changes?")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Your edits will be lost if you continue.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing while closed", () => {
+    setup({ open: false });
+
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("omits the close button so the choice must be explicit", () => {
+    setup();
+
+    expect(
+      screen.queryByRole("button", { name: /close dialog/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("confirms and closes when the confirming action is pressed", async () => {
+    const user = userEvent.setup();
+    const { onConfirm, onCancel, onOpenChange } = setup();
+
+    await user.click(screen.getByRole("button", { name: "Discard changes" }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("cancels without confirming when the dismissing action is pressed", async () => {
+    const user = userEvent.setup();
+    const { onConfirm, onCancel, onOpenChange } = setup();
+
+    await user.click(screen.getByRole("button", { name: "Keep editing" }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("cancels without confirming when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const { onConfirm, onCancel } = setup();
+
+    await user.keyboard("{Escape}");
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("defaults to a destructive confirming action and generic labels", () => {
+    setup({
+      confirmLabel: undefined,
+      cancelLabel: undefined,
+      description: undefined,
+    });
+
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+});

--- a/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -1,0 +1,72 @@
+import type { ConfirmDialogProps } from "./ConfirmDialog.types";
+import { Button } from "../Button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../Dialog";
+
+/**
+ * Confirmation prompt for destructive or irreversible actions.
+ *
+ * Composed from the shared Dialog primitives so it inherits the app's overlay,
+ * focus trap, motion and escape handling rather than introducing new dialog
+ * behaviour.
+ */
+export const ConfirmDialog = ({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  confirmVariant = "destructive",
+  cancelVariant = "secondary",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) => {
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      onCancel?.();
+    }
+    onOpenChange(nextOpen);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent size="sm" withCloseButton={false} role="alertdialog">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        {description && (
+          <DialogBody>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogBody>
+        )}
+        <DialogFooter>
+          <Button
+            variant={cancelVariant}
+            size="sm"
+            onClick={() => handleOpenChange(false)}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={confirmVariant}
+            size="sm"
+            onClick={() => {
+              onConfirm();
+              onOpenChange(false);
+            }}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/ConfirmDialog/ConfirmDialog.types.ts
+++ b/src/components/ConfirmDialog/ConfirmDialog.types.ts
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+
+import type { ButtonVariant } from "../Button/Button.types";
+
+export interface ConfirmDialogProps {
+  /** Whether the dialog is visible. */
+  open: boolean;
+
+  /** Called when the dialog requests to open or close. */
+  onOpenChange: (open: boolean) => void;
+
+  /** Short, action-oriented question, e.g. "Discard unsaved changes?". */
+  title: string;
+
+  /** Optional supporting copy explaining the consequence of confirming. */
+  description?: ReactNode;
+
+  /**
+   * Label of the confirming action.
+   * @default "Confirm"
+   */
+  confirmLabel?: string;
+
+  /**
+   * Label of the dismissing action.
+   * @default "Cancel"
+   */
+  cancelLabel?: string;
+
+  /**
+   * Visual hierarchy of the confirming action.
+   * @default "destructive"
+   */
+  confirmVariant?: ButtonVariant;
+
+  /**
+   * Visual hierarchy of the dismissing action. Defaults to the bordered
+   * secondary style so the safe choice reads as the stronger control next to a
+   * destructive confirmation.
+   * @default "secondary"
+   */
+  cancelVariant?: ButtonVariant;
+
+  /** Called when the user confirms. */
+  onConfirm: () => void;
+
+  /** Called when the user dismisses, whether by button, overlay, or Escape. */
+  onCancel?: () => void;
+}

--- a/src/components/ConfirmDialog/index.ts
+++ b/src/components/ConfirmDialog/index.ts
@@ -1,0 +1,2 @@
+export * from "./ConfirmDialog";
+export * from "./ConfirmDialog.types";

--- a/src/components/RecipePage/RecipePage.test.tsx
+++ b/src/components/RecipePage/RecipePage.test.tsx
@@ -1,0 +1,207 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRouter } from "next/router";
+
+import { RecipePage } from "./RecipePage";
+import { useRecipeViewSaveState } from "../RecipeView/RecipeViewSaveStateContext";
+
+import { fetchRecipe } from "../../clientToServer";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("../../clientToServer", () => ({
+  fetchRecipe: jest.fn(),
+}));
+
+// Stubbed so the test exercises RecipePage's guard wiring rather than the
+// full recipe view. The stub still drives the real save-state context.
+jest.mock("../RecipeView", () => ({
+  RecipeView: () => {
+    const saveState = useRecipeViewSaveState();
+    return (
+      <button type="button" onClick={() => saveState?.updateTitle("Edited")}>
+        Make an edit
+      </button>
+    );
+  },
+}));
+
+const recipe = {
+  _id: "abc",
+  title: "Original",
+  data: "Body",
+  emoji: "🍲",
+  tags: [],
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+const routeHandlers = new Set<(url: string) => void>();
+let popStateHandler: (state: { url: string }) => boolean = () => true;
+const push = jest.fn(() => Promise.resolve(true));
+
+const navigate = (url: string) => {
+  let blocked = false;
+  routeHandlers.forEach((handler) => {
+    try {
+      handler(url);
+    } catch {
+      blocked = true;
+    }
+  });
+  return blocked;
+};
+
+beforeEach(() => {
+  routeHandlers.clear();
+  popStateHandler = () => true;
+  push.mockClear();
+  (fetchRecipe as jest.Mock).mockResolvedValue(recipe);
+  (useRouter as jest.Mock).mockReturnValue({
+    asPath: "/recipes/abc",
+    query: { recipes: "abc" },
+    push,
+    beforePopState: (handler: (state: { url: string }) => boolean) => {
+      popStateHandler = handler;
+    },
+    events: {
+      on: (event: string, handler: (url: string) => void) => {
+        if (event === "routeChangeStart") {
+          routeHandlers.add(handler);
+        }
+      },
+      off: (event: string, handler: (url: string) => void) => {
+        if (event === "routeChangeStart") {
+          routeHandlers.delete(handler);
+        }
+      },
+      emit: jest.fn(),
+    },
+  });
+});
+
+const renderPage = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RecipePage />
+    </QueryClientProvider>
+  );
+};
+
+const makeDirty = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(await screen.findByRole("button", { name: "Make an edit" }));
+  await screen.findByRole("button", { name: "Save" });
+};
+
+describe("RecipePage unsaved changes", () => {
+  it("lets navigation through while nothing is edited", async () => {
+    renderPage();
+    await screen.findByRole("button", { name: "Make an edit" });
+
+    expect(navigate("/recipes/other")).toBe(false);
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("prompts instead of leaving when navigation is attempted mid-edit", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await makeDirty(user);
+
+    let blocked = false;
+    act(() => {
+      blocked = navigate("/recipes/other");
+    });
+    expect(blocked).toBe(true);
+
+    expect(
+      await screen.findByText("Discard unsaved changes?")
+    ).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("prompts instead of leaving when the back button is pressed mid-edit", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await makeDirty(user);
+
+    let allowed = true;
+    act(() => {
+      allowed = popStateHandler({ url: "/recipes/other" });
+    });
+    expect(allowed).toBe(false);
+
+    expect(
+      await screen.findByText("Discard unsaved changes?")
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the edit and stays put when the user chooses to keep editing", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await makeDirty(user);
+    act(() => {
+      navigate("/recipes/other");
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Keep editing" })
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+    );
+    expect(push).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
+  it("completes the navigation when the user chooses to discard", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await makeDirty(user);
+    act(() => {
+      navigate("/recipes/other");
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Discard changes" })
+    );
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/recipes/other"));
+  });
+
+  it("prompts before the Cancel button throws the edit away", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await makeDirty(user);
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(
+      await screen.findByText("Discard unsaved changes?")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
+  it("discards the edit only after Cancel is confirmed", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await makeDirty(user);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await user.click(
+      await screen.findByRole("button", { name: "Discard changes" })
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Save" })
+      ).not.toBeInTheDocument()
+    );
+  });
+});

--- a/src/components/RecipePage/RecipePage.tsx
+++ b/src/components/RecipePage/RecipePage.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { LexicalEditor } from "lexical";
 import { useRouter } from "next/router";
 
+import { ConfirmDialog } from "../ConfirmDialog";
 import { LoadingScreen, ErrorScreen } from "../FallbackScreens";
 import { RecipeSaveBar } from "../RecipeSaveBar";
 import type { SaveBarStatus } from "../RecipeSaveBar/RecipeSaveBar.types";
@@ -15,6 +16,7 @@ import {
 import { exportRecipeMarkdown } from "../TextEditor/textEditorConfig";
 
 import { fetchRecipe } from "../../clientToServer";
+import { useUnsavedChangesGuard } from "../../hooks";
 
 type RecipePageInnerProps = {
   recipeId: string;
@@ -26,6 +28,8 @@ function RecipePageInner({ recipeId, onCancelReset }: RecipePageInnerProps) {
   const [status, setStatus] = useState<SaveBarStatus>("idle");
   const saveState = useRecipeViewSaveState();
   const queryClient = useQueryClient();
+  const isDirty = saveState?.isDirty ?? false;
+  const guard = useUnsavedChangesGuard({ enabled: isDirty });
 
   const {
     data: recipe,
@@ -105,14 +109,30 @@ function RecipePageInner({ recipeId, onCancelReset }: RecipePageInnerProps) {
   };
 
   const onCancel = () => {
-    setStatus("idle");
-    onCancelReset();
+    guard.guardAction(() => {
+      setStatus("idle");
+      onCancelReset();
+    });
   };
 
   return (
     <>
       <RecipeView recipe={recipe} viewingMode="editor" editorRef={editorRef} />
       <RecipeSaveBar status={status} onSave={onSave} onCancel={onCancel} />
+      <ConfirmDialog
+        open={guard.isBlocked}
+        onOpenChange={(open) => {
+          if (!open) {
+            guard.stay();
+          }
+        }}
+        title="Discard unsaved changes?"
+        description="Your edits to this recipe have not been saved yet. They will be lost if you continue."
+        confirmLabel="Discard changes"
+        cancelLabel="Keep editing"
+        onConfirm={guard.discard}
+        onCancel={guard.stay}
+      />
     </>
   );
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,6 +18,7 @@ export * from "./Toast";
 export * from "./Accordion";
 export * from "./AppShell";
 export * from "./Auth";
+export * from "./ConfirmDialog";
 export * from "./Dialog";
 export * from "./Dropdown";
 export * from "./Menu";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./useMediaQuery";
+export * from "./useUnsavedChangesGuard";

--- a/src/hooks/useUnsavedChangesGuard.test.tsx
+++ b/src/hooks/useUnsavedChangesGuard.test.tsx
@@ -1,0 +1,251 @@
+import { act, renderHook } from "@testing-library/react";
+import { useRouter } from "next/router";
+
+import { useUnsavedChangesGuard } from "./useUnsavedChangesGuard";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+type RouteHandler = (url: string) => void;
+type PopStateHandler = (state: { url: string }) => boolean;
+
+const createRouterMock = () => {
+  const routeChangeStart = new Set<RouteHandler>();
+  let popStateHandler: PopStateHandler = () => true;
+
+  const router = {
+    asPath: "/recipes/abc",
+    push: jest.fn(() => Promise.resolve(true)),
+    beforePopState: jest.fn((handler: PopStateHandler) => {
+      popStateHandler = handler;
+    }),
+    events: {
+      on: jest.fn((event: string, handler: RouteHandler) => {
+        if (event === "routeChangeStart") {
+          routeChangeStart.add(handler);
+        }
+      }),
+      off: jest.fn((event: string, handler: RouteHandler) => {
+        if (event === "routeChangeStart") {
+          routeChangeStart.delete(handler);
+        }
+      }),
+      emit: jest.fn(),
+    },
+    /** Simulates a Link click or router.push, returning whether it was blocked. */
+    navigate: (url: string) => {
+      let blocked = false;
+      routeChangeStart.forEach((handler) => {
+        try {
+          handler(url);
+        } catch {
+          blocked = true;
+        }
+      });
+      return blocked;
+    },
+    /** Simulates the browser back button. */
+    popState: (url: string) => popStateHandler({ url }),
+    hasRouteListeners: () => routeChangeStart.size > 0,
+  };
+
+  return router;
+};
+
+let router: ReturnType<typeof createRouterMock>;
+
+beforeEach(() => {
+  router = createRouterMock();
+  (useRouter as jest.Mock).mockReturnValue(router);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useUnsavedChangesGuard", () => {
+  describe("when there is nothing unsaved", () => {
+    it("lets navigation through untouched", () => {
+      const { result } = renderHook(() =>
+        useUnsavedChangesGuard({ enabled: false })
+      );
+
+      expect(router.navigate("/recipes/other")).toBe(false);
+      expect(result.current.isBlocked).toBe(false);
+    });
+
+    it("does not warn on tab close", () => {
+      const addEventListener = jest.spyOn(window, "addEventListener");
+
+      renderHook(() => useUnsavedChangesGuard({ enabled: false }));
+
+      expect(addEventListener).not.toHaveBeenCalledWith(
+        "beforeunload",
+        expect.any(Function)
+      );
+      addEventListener.mockRestore();
+    });
+
+    it("runs a destructive action immediately without prompting", () => {
+      const action = jest.fn();
+      const { result } = renderHook(() =>
+        useUnsavedChangesGuard({ enabled: false })
+      );
+
+      act(() => result.current.guardAction(action));
+
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(result.current.isBlocked).toBe(false);
+    });
+  });
+
+  describe("when there is unsaved work", () => {
+    it("blocks in-app navigation and reports it", () => {
+      const { result } = renderHook(() =>
+        useUnsavedChangesGuard({ enabled: true })
+      );
+
+      let blocked = false;
+      act(() => {
+        blocked = router.navigate("/recipes/other");
+      });
+
+      expect(blocked).toBe(true);
+      expect(result.current.isBlocked).toBe(true);
+      expect(router.push).not.toHaveBeenCalled();
+    });
+
+    it("blocks the browser back button and restores the current URL", () => {
+      const pushState = jest.spyOn(window.history, "pushState");
+      const { result } = renderHook(() =>
+        useUnsavedChangesGuard({ enabled: true })
+      );
+
+      let allowed = true;
+      act(() => {
+        allowed = router.popState("/recipes/other");
+      });
+
+      expect(allowed).toBe(false);
+      expect(result.current.isBlocked).toBe(true);
+      expect(pushState).toHaveBeenCalledWith(null, "", "/recipes/abc");
+      pushState.mockRestore();
+    });
+
+    it("warns before the tab is closed or reloaded", () => {
+      renderHook(() => useUnsavedChangesGuard({ enabled: true }));
+
+      const event = new Event("beforeunload", { cancelable: true });
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("ignores a route change to the page it is already on", () => {
+      const { result } = renderHook(() =>
+        useUnsavedChangesGuard({ enabled: true })
+      );
+
+      act(() => {
+        expect(router.navigate("/recipes/abc")).toBe(false);
+      });
+
+      expect(result.current.isBlocked).toBe(false);
+    });
+
+    it("stays on the page and keeps the work when the user backs out", () => {
+      const { result } = renderHook(() =>
+        useUnsavedChangesGuard({ enabled: true })
+      );
+
+      act(() => {
+        router.navigate("/recipes/other");
+      });
+      act(() => result.current.stay());
+
+      expect(result.current.isBlocked).toBe(false);
+      expect(router.push).not.toHaveBeenCalled();
+    });
+
+    it("completes the held navigation when the user discards", () => {
+      const { result } = renderHook(() =>
+        useUnsavedChangesGuard({ enabled: true })
+      );
+
+      act(() => {
+        router.navigate("/recipes/other");
+      });
+      act(() => result.current.discard());
+
+      expect(result.current.isBlocked).toBe(false);
+      expect(router.push).toHaveBeenCalledWith("/recipes/other");
+    });
+
+    it("does not re-block the navigation it was told to allow", () => {
+      const { result } = renderHook(() =>
+        useUnsavedChangesGuard({ enabled: true })
+      );
+
+      act(() => {
+        router.navigate("/recipes/other");
+      });
+      act(() => result.current.discard());
+
+      let blockedAgain = false;
+      act(() => {
+        blockedAgain = router.navigate("/recipes/other");
+      });
+
+      expect(blockedAgain).toBe(false);
+    });
+
+    it("holds a destructive action until the user confirms it", () => {
+      const action = jest.fn();
+      const { result } = renderHook(() =>
+        useUnsavedChangesGuard({ enabled: true })
+      );
+
+      act(() => result.current.guardAction(action));
+      expect(action).not.toHaveBeenCalled();
+      expect(result.current.isBlocked).toBe(true);
+
+      act(() => result.current.discard());
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(router.push).not.toHaveBeenCalled();
+    });
+
+    it("abandons a destructive action when the user backs out", () => {
+      const action = jest.fn();
+      const { result } = renderHook(() =>
+        useUnsavedChangesGuard({ enabled: true })
+      );
+
+      act(() => result.current.guardAction(action));
+      act(() => result.current.stay());
+
+      expect(action).not.toHaveBeenCalled();
+      expect(result.current.isBlocked).toBe(false);
+    });
+  });
+
+  it("releases every listener once the work is saved", () => {
+    const removeEventListener = jest.spyOn(window, "removeEventListener");
+    const { rerender } = renderHook(
+      ({ enabled }) => useUnsavedChangesGuard({ enabled }),
+      { initialProps: { enabled: true } }
+    );
+
+    expect(router.hasRouteListeners()).toBe(true);
+
+    rerender({ enabled: false });
+
+    expect(router.hasRouteListeners()).toBe(false);
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "beforeunload",
+      expect.any(Function)
+    );
+    expect(router.navigate("/recipes/other")).toBe(false);
+    removeEventListener.mockRestore();
+  });
+});

--- a/src/hooks/useUnsavedChangesGuard.ts
+++ b/src/hooks/useUnsavedChangesGuard.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/router";
+
+/** Aborts a Next.js route transition the user has not confirmed yet. */
+class RouteChangeAbortedError extends Error {
+  /** Next.js swallows route errors flagged as cancelled instead of rethrowing. */
+  readonly cancelled = true;
+
+  constructor() {
+    super("Route change aborted by the unsaved changes guard");
+    this.name = "RouteChangeAbortedError";
+  }
+}
+
+export interface UseUnsavedChangesGuardOptions {
+  /** While true, navigation away from the page is intercepted. */
+  enabled: boolean;
+}
+
+export interface UnsavedChangesGuard {
+  /** True while a navigation is held back awaiting the user's decision. */
+  isBlocked: boolean;
+
+  /** Abandons the held navigation and stays on the page. */
+  stay: () => void;
+
+  /** Completes the held navigation, discarding whatever was unsaved. */
+  discard: () => void;
+
+  /**
+   * Runs an action that would destroy unsaved work, prompting first when the
+   * guard is enabled. Use for in-page destructive actions such as Cancel.
+   */
+  guardAction: (action: () => void) => void;
+}
+
+/**
+ * Intercepts every way a user can leave unsaved work behind: in-app navigation,
+ * the browser back button, tab close or reload, and destructive in-page actions.
+ *
+ * The hook owns only the decision to block; rendering the prompt is left to the
+ * caller so it can use the app's own ConfirmDialog rather than window.confirm.
+ */
+export const useUnsavedChangesGuard = ({
+  enabled,
+}: UseUnsavedChangesGuardOptions): UnsavedChangesGuard => {
+  const router = useRouter();
+  const [isBlocked, setIsBlocked] = useState(false);
+  const pendingUrl = useRef<string | null>(null);
+  const pendingAction = useRef<(() => void) | null>(null);
+  const bypass = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () =>
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    const handleRouteChangeStart = (url: string) => {
+      if (bypass.current) {
+        bypass.current = false;
+        return;
+      }
+      if (url === router.asPath) {
+        return;
+      }
+
+      pendingUrl.current = url;
+      pendingAction.current = null;
+      setIsBlocked(true);
+      const abort = new RouteChangeAbortedError();
+      router.events.emit("routeChangeError", abort, url, { shallow: false });
+      throw abort;
+    };
+
+    // Back/forward navigation is cancelled before it reaches routeChangeStart,
+    // so the popped history entry has to be pushed back to keep the URL honest.
+    router.beforePopState(({ url }) => {
+      if (bypass.current) {
+        bypass.current = false;
+        return true;
+      }
+      pendingUrl.current = url;
+      pendingAction.current = null;
+      setIsBlocked(true);
+      window.history.pushState(null, "", router.asPath);
+      return false;
+    });
+
+    router.events.on("routeChangeStart", handleRouteChangeStart);
+    return () => {
+      router.events.off("routeChangeStart", handleRouteChangeStart);
+      router.beforePopState(() => true);
+    };
+  }, [enabled, router]);
+
+  const stay = useCallback(() => {
+    pendingUrl.current = null;
+    pendingAction.current = null;
+    setIsBlocked(false);
+  }, []);
+
+  const discard = useCallback(() => {
+    const url = pendingUrl.current;
+    const action = pendingAction.current;
+    pendingUrl.current = null;
+    pendingAction.current = null;
+    setIsBlocked(false);
+
+    if (action) {
+      action();
+      return;
+    }
+    if (url) {
+      bypass.current = true;
+      void router.push(url);
+    }
+  }, [router]);
+
+  const guardAction = useCallback(
+    (action: () => void) => {
+      if (!enabled) {
+        action();
+        return;
+      }
+      pendingAction.current = action;
+      pendingUrl.current = null;
+      setIsBlocked(true);
+    },
+    [enabled]
+  );
+
+  return { isBlocked, stay, discard, guardAction };
+};

--- a/src/stories/components/ConfirmDialog.stories.tsx
+++ b/src/stories/components/ConfirmDialog.stories.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Button } from "../../components/Button";
+import { ConfirmDialog } from "../../components/ConfirmDialog";
+
+const meta: Meta<typeof ConfirmDialog> = {
+  title: "Components/ConfirmDialog",
+  component: ConfirmDialog,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ConfirmDialog>;
+
+const ConfirmDialogPreview: React.FC<{
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  confirmVariant?: "primary" | "destructive";
+  cancelVariant?: "secondary" | "ghost";
+  triggerLabel: string;
+}> = ({ triggerLabel, ...dialogProps }) => {
+  const [open, setOpen] = React.useState(false);
+  const [outcome, setOutcome] = React.useState<string | null>(null);
+
+  return (
+    <div style={{ display: "grid", gap: "12px", justifyItems: "start" }}>
+      <Button variant="secondary" onClick={() => setOpen(true)}>
+        {triggerLabel}
+      </Button>
+      {outcome && <span>Last choice: {outcome}</span>}
+      <ConfirmDialog
+        {...dialogProps}
+        open={open}
+        onOpenChange={setOpen}
+        onConfirm={() => setOutcome("confirmed")}
+        onCancel={() => setOutcome("cancelled")}
+      />
+    </div>
+  );
+};
+
+export const DiscardUnsavedChanges: Story = {
+  render: () => (
+    <ConfirmDialogPreview
+      triggerLabel="Leave the recipe"
+      title="Discard unsaved changes?"
+      description="Your edits to this recipe have not been saved yet. They will be lost if you continue."
+      confirmLabel="Discard changes"
+      cancelLabel="Keep editing"
+    />
+  ),
+};
+
+export const WithoutDescription: Story = {
+  render: () => (
+    <ConfirmDialogPreview
+      triggerLabel="Delete the recipe"
+      title="Delete this recipe?"
+      confirmLabel="Delete"
+    />
+  ),
+};
+
+export const NonDestructive: Story = {
+  render: () => (
+    <ConfirmDialogPreview
+      triggerLabel="Publish the recipe"
+      title="Publish this recipe?"
+      description="Anyone with the link will be able to view it."
+      confirmLabel="Publish"
+      confirmVariant="primary"
+      cancelVariant="ghost"
+    />
+  ),
+};

--- a/src/stories/components/TextEditor.stories.tsx
+++ b/src/stories/components/TextEditor.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+import { TextEditor } from "../../components/TextEditor";
+
+const recipeMarkdown = `# Brown Butter Chocolate Chip Cookies
+
+A deeply caramelized cookie with crisp edges, a soft center, and enough salt to balance the chocolate.
+
+## Ingredients
+
+- 225 g unsalted butter
+- 200 g dark brown sugar
+- 100 g granulated sugar
+- 1 large egg
+- 1 egg yolk
+- 2 tsp vanilla extract
+- 280 g all-purpose flour
+- 1 tsp baking soda
+- 1 tsp kosher salt
+- 250 g dark chocolate, roughly chopped
+
+## Method
+
+1. Brown the butter until the milk solids are deeply golden and smell nutty.
+2. Cool for 15 minutes, then whisk with both sugars until glossy.
+3. Add the egg, yolk, and vanilla; whisk until the mixture lightens slightly.
+4. Fold in the dry ingredients just until no flour streaks remain.
+5. Add the chocolate and chill the dough for at least 1 hour.
+6. Bake at 180°C for 11–13 minutes.
+
+> Pull the cookies when the edges are set but the centers still look slightly underdone.
+
+### Finish
+
+Sprinkle with flaky salt immediately after baking. Rest on the tray for 10 minutes before transferring.
+
+| Yield | Prep | Bake |
+| --- | --- | --- |
+| 16 cookies | 25 minutes | 12 minutes |
+
+---
+
+**Storage:** Keep airtight for 3 days, or freeze portioned dough for up to 2 months.`;
+
+const meta: Meta<typeof TextEditor> = {
+  title: "Components/TextEditor",
+  component: TextEditor,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    text: recipeMarkdown,
+  },
+  decorators: [
+    (Story) => (
+      <main
+        style={{
+          width: "min(100%, 920px)",
+          minHeight: "100vh",
+          margin: "0 auto",
+          padding: "72px 48px 120px",
+        }}
+      >
+        <Story />
+      </main>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextEditor>;
+
+export const Editable: Story = {
+  args: {
+    viewingMode: "editor",
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    viewingMode: "viewer",
+  },
+};
+
+export const CompactRecipe: Story = {
+  args: {
+    viewingMode: "viewer",
+    text: `## Simple Vinaigrette
+
+- 3 tbsp olive oil
+- 1 tbsp lemon juice
+- 1 tsp Dijon mustard
+- Salt and pepper
+
+1. Whisk the lemon juice, mustard, salt, and pepper.
+2. Stream in the oil until emulsified.
+
+**Use immediately.**`,
+  },
+};

--- a/src/stories/globalProviders.tsx
+++ b/src/stories/globalProviders.tsx
@@ -14,11 +14,20 @@ const mockSession: Session = {
   expires: "2099-12-31",
 };
 
-const StoryWrapper: React.FC<{ Story: React.ComponentType }> = ({ Story }) => {
+const StoryWrapper: React.FC<{ Story: React.ComponentType; theme: string }> = ({
+  Story,
+  theme,
+}) => {
   const [searchBoxValue, setSearchBoxValue] = React.useState("");
   const onSearchBoxValueChange = (incomingValue: string) => {
     setSearchBoxValue(incomingValue);
   };
+
+  // Design tokens are published on [data-theme], so stories must set it to
+  // render with the same colours and typography as the application.
+  React.useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+  }, [theme]);
 
   return (
     <SearchBoxProvider value={{ searchBoxValue, onSearchBoxValueChange }}>
@@ -31,9 +40,12 @@ const StoryWrapper: React.FC<{ Story: React.ComponentType }> = ({ Story }) => {
 
 export const withGlobalProviders = (
   Story: React.ComponentType,
-  _context: StoryContext,
+  context: StoryContext,
 ) => (
   <SessionProvider session={mockSession}>
-    <StoryWrapper Story={Story} />
+    <StoryWrapper
+      Story={Story}
+      theme={(context.globals.themeMode as string) ?? "light"}
+    />
   </SessionProvider>
 );


### PR DESCRIPTION
## Problem

The recipe page is permanently an editor — `RecipePage.tsx` hardcodes `viewingMode="editor"` — and sits next to persistent sidebar navigation. Nothing guarded work in progress:

- A repo-wide grep for `beforeunload|routeChangeStart` returned **0 matches**.
- `saveState.isDirty` already tracked title, body, emoji and tags, but its only consumers were showing the save bar and enabling Save.
- `Cancel` discarded everything instantly via `setResetKey(k + 1)`, which remounts the provider and also destroys Lexical's undo history, so Ctrl+Z could not recover it.

A sidebar click, the back button, a reload, or one mis-click on Cancel silently and irrecoverably destroyed a recipe the user had just typed.

## Change

- **`useUnsavedChangesGuard`** (`src/hooks`) owns only the *decision* to block and returns `{ isBlocked, stay, discard, guardAction }`. It covers in-app navigation, the browser back button, tab close/reload, and in-page destructive actions. It renders nothing, so callers prompt with the app's own dialog instead of `window.confirm`.
- **`ConfirmDialog`** (`src/components`) is composed entirely from the existing Radix `Dialog` primitives and `Button` variants — `role="alertdialog"`, no close button so the choice is explicit. **No new design-system vocabulary**: the safe action uses the existing bordered `secondary` variant against the existing subdued red `destructive` variant, and receives initial focus.
- **`RecipePage`** wires the two to the flag that already existed.

Also restores the Storybook `global.css` import and `data-theme` decorator, which a hard reset had reverted — stories were rendering in Times New Roman with dead tokens.

### Notes on the Next.js guard

`routeChangeStart` aborts by throwing an `Error` carrying `cancelled = true`, which Next swallows cleanly (a bare string throw also violates `@typescript-eslint/only-throw-error`). `routeChangeStart` never fires for back/forward, so the back button is handled by `beforePopState` plus a `history.pushState` to keep the address bar truthful.

## Validation

- **27 targeted tests**, 15.7s: 7 ConfirmDialog (role, labels, Escape, defaults, closed state), 13 hook (block, back button, beforeunload, same-URL no-op, stay, discard, bypass-on-resume, deferred action, listener teardown), 7 RecipePage integration (navigate/back/Cancel prompts and both outcomes).
- Full suite: **356 passed / 43 suites**.
- `npm run lint`: no warnings or errors. `npm run build`: exit 0.
- Chromium against the Storybook story: `alertdialog` role, focus trapped on **Keep editing**, background `aria-hidden="true"`, Escape → cancelled, Enter → confirmed, Inter 13px on both actions, **0 console or page errors**.