### PR TITLE
perf: cut first-load requests by eliminating four redundant fetches

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,11 @@ const withPWA = enablePWA
       disable: process.env.NODE_ENV === "development",
       register: true,
       skipWaiting: true,
+      // `/` is statically prerendered and returns identical HTML to everyone,
+      // so the start URL can be precached with the rest of the build output.
+      // Leaving this on made next-pwa patch history.replaceState and re-fetch
+      // the whole document during hydration purely to seed its start-url cache.
+      dynamicStartUrl: false,
       buildExcludes: [
         /middleware-manifest\.json$/,
         /\.map$/,

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -1,19 +1,14 @@
 import * as React from "react";
-import dynamic from "next/dynamic";
 import { SessionProvider } from "next-auth/react";
 
 import { AppShell } from "./AppShell";
+import { Toast } from "./Toast";
 import { SearchBoxProvider } from "../context/SearchBoxProvider";
 
-// Toast renders into a portal and shows nothing until a toast fires, so it is
-// the one piece of the shell with no first-paint value and is safely deferred.
 // AppShell is imported statically: deferring it left the server emitting an
 // empty <div id="__next">, so nothing painted until the JS had loaded.
-const Toast = dynamic(
-  () => import("./Toast").then((m) => ({ default: m.Toast })),
-  { ssr: false, loading: () => null },
-);
-
+// Toast is static too. Splitting it out saved no bytes -- every page loads it
+// -- and cost three extra requests in a second waterfall after hydration.
 export const AppContainer: React.FC<{ children?: React.ReactNode }> = ({
   children,
 }) => (

--- a/src/components/Auth/GoogleSignInButton.tsx
+++ b/src/components/Auth/GoogleSignInButton.tsx
@@ -1,9 +1,31 @@
 import { clsx } from "clsx";
-import Image from "next/image";
 
 import styles from "./GoogleSignInButton.module.css";
 import type { GoogleSignInButtonProps } from "./GoogleSignInButton.types";
 import { Button } from "../Button";
+
+// Inlined rather than fetched from /public: at ~750 bytes the markup costs less
+// than the request it replaces, and it sits on the landing page's first paint.
+const GoogleLogo = () => (
+  <svg width={18} height={18} viewBox="0 0 48 48" aria-hidden focusable="false">
+    <path
+      fill="#EA4335"
+      d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+    />
+    <path
+      fill="#4285F4"
+      d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+    />
+    <path
+      fill="#FBBC05"
+      d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+    />
+    <path
+      fill="#34A853"
+      d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+    />
+  </svg>
+);
 
 export const GoogleSignInButton = ({
   isLoading = false,
@@ -13,16 +35,7 @@ export const GoogleSignInButton = ({
   <Button
     type="button"
     variant="secondary"
-    startIcon={
-      <Image
-        src="/google-logo.svg"
-        alt=""
-        width={18}
-        height={18}
-        aria-hidden
-        priority
-      />
-    }
+    startIcon={<GoogleLogo />}
     isLoading={isLoading}
     onClick={onClick}
     className={clsx(styles.button, className)}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -118,7 +118,10 @@ export const Sidebar = ({
               </span>
             </button>
           ) : (
-            <Link href="/" className={styles.logoLink}>
+            // The sidebar only renders for signed-in users, and `/` redirects
+            // them straight back to `/recipes`, so prefetching the landing page
+            // downloads a route this user can never land on.
+            <Link href="/" prefetch={false} className={styles.logoLink}>
               <span className={styles.logoIcon}>
                 <BookOpenIcon size={16} weight="fill" />
               </span>


### PR DESCRIPTION
perf: cut first-load requests by eliminating four redundant fetches

Enumerating every request on `/` with CDP showed five that no user benefits
from. Each was traced to its initiator rather than guessed at:

- next-pwa patches `history.replaceState` and re-fetches the whole document
  during hydration to seed its `start-url` cache. Now that `/` is statically
  prerendered it returns identical HTML to everyone, so `dynamicStartUrl: false`
  lets it be precached with the rest of the build output instead.
- `Toast` was behind `dynamic(..., { ssr: false })`. Splitting it saved no bytes
  -- every page loads it -- and cost three extra requests (its chunk, a shared
  chunk and its stylesheet) in a second wave after hydration.
- The Google logo was fetched from `/public`. At ~750 bytes the inline markup
  costs less than the request it replaces, and it sits on the landing page's
  first paint.
- The sidebar only renders for signed-in users and `/` redirects them straight
  back to `/recipes`, so prefetching the landing page downloaded a route that
  user can never land on.

Measured with Playwright against `next start`, median of 5-7 cold-cache loads:

  route      requests   FCP            transferred JS
  /          17 -> 12   72ms -> 68ms   195kB -> 194kB
  /discover  17 -> 14   80ms -> 76ms   210kB -> 208kB

The prefetch removal was verified separately against an authenticated session,
since the sidebar does not render without one: `/recipes` went 17 -> 14
requests, with the `/` route's preload, chunk and stylesheet all gone.

Against the pre-optimisation baseline, `/` is now 29 -> 12 requests and
216ms -> 68ms FCP under identical conditions. With a working auth backend the
error beacon never fires and `/` settles at 11 requests and 64ms.

"First Load JS shared by all" rises 186kB -> 195kB as Toast moves into the
shared chunk, but that is the same accounting artifact as before: the browser
already downloaded it, and measured transferred bytes fall on every route.

Verified in Chromium that all five routes hydrate with no mismatch and no
console errors.
