### PR TITLE
perf(auth): stop querying MongoDB on every authenticated request

### DIFF
--- a/src/__tests__/api/auth/nextauth.test.ts
+++ b/src/__tests__/api/auth/nextauth.test.ts
@@ -1,0 +1,87 @@
+jest.mock("src/utils/db", () => ({ getDb: jest.fn() }));
+// next-auth's entrypoint pulls in ESM-only crypto deps that jest cannot parse,
+// so stub the wiring and exercise the real `authOptions` callbacks.
+jest.mock("next-auth", () => ({ __esModule: true, default: jest.fn() }));
+jest.mock("next-auth/providers/google", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ id: "google" })),
+}));
+
+import type { Session } from "next-auth";
+import type { JWT } from "next-auth/jwt";
+
+import { getDb } from "src/utils/db";
+
+import { authOptions } from "../../../pages/api/auth/[...nextauth]";
+
+const findOne = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getDb as jest.Mock).mockResolvedValue({
+    collection: () => ({ findOne }),
+  });
+});
+
+const runJwt = (token: JWT) =>
+  authOptions.callbacks?.jwt?.({ token } as never) as Promise<JWT>;
+
+const runSession = (session: Session, token: JWT) =>
+  authOptions.callbacks?.session?.({
+    session,
+    token,
+  } as never) as Promise<Session>;
+
+describe("auth callbacks", () => {
+  it("resolves the user id once and caches it on the token", async () => {
+    findOne.mockResolvedValue({ _id: "user-123" });
+
+    const token = await runJwt({ email: "cook@example.com" });
+
+    expect(token.userId).toBe("user-123");
+    expect(findOne).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not touch the database once the token carries the user id", async () => {
+    await runJwt({ email: "cook@example.com", userId: "user-123" });
+
+    expect(getDb).not.toHaveBeenCalled();
+    expect(findOne).not.toHaveBeenCalled();
+  });
+
+  it("retries the lookup when the user document does not exist yet", async () => {
+    // events.signIn creates the user document *after* callbacks.jwt runs, so a
+    // brand-new account must not cache a missing id permanently.
+    findOne.mockResolvedValueOnce(null);
+    const first = await runJwt({ email: "new@example.com" });
+    expect(first.userId).toBeUndefined();
+
+    findOne.mockResolvedValueOnce({ _id: "user-456" });
+    const second = await runJwt(first);
+    expect(second.userId).toBe("user-456");
+  });
+
+  it("keeps the user signed in when the lookup fails", async () => {
+    // Throwing out of the callback makes NextAuth return an empty session,
+    // which signs the user out over a transient database blip.
+    (getDb as jest.Mock).mockRejectedValueOnce(new Error("connection refused"));
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const token = await runJwt({ email: "cook@example.com", name: "Cook" });
+
+    expect(token.name).toBe("Cook");
+    expect(token.userId).toBeUndefined();
+  });
+
+  it("builds the session from the token without querying the database", async () => {
+    const session = { user: { email: "cook@example.com" } } as Session;
+
+    const result = await runSession(session, {
+      email: "cook@example.com",
+      userId: "user-123",
+    });
+
+    expect(result.user.id).toBe("user-123");
+    expect(getDb).not.toHaveBeenCalled();
+  });
+});

--- a/src/clients/mongo.ts
+++ b/src/clients/mongo.ts
@@ -42,13 +42,18 @@ const fallbackUri = `mongodb://${username}:${password}@${cluster}:27017/${dbName
 
 // Base connection options
 const baseOptions: MongoClientOptions = {
-  connectTimeoutMS: 30000,
+  connectTimeoutMS: 10000,
   socketTimeoutMS: 45000,
-  maxPoolSize: 50,
+  // Serverless runs many short-lived instances; a large pool per instance
+  // multiplies into a connection storm against the cluster.
+  maxPoolSize: 10,
+  // Without this the driver waits out its 30s default before surfacing a
+  // transient cluster blip, which is the difference between a slow page and a
+  // hung one.
+  serverSelectionTimeoutMS: 5000,
   retryWrites: true,
   family: 4, // Force IPv4 for mobile hotspot compatibility
   ...(process.env.NODE_ENV === "development" && {
-    serverSelectionTimeoutMS: 5000,
     heartbeatFrequencyMS: 2000,
   }),
 };
@@ -65,8 +70,6 @@ const directOptions: MongoClientOptions = {
   ...baseOptions,
   directConnection: false,
 };
-
-let clientPromise: Promise<MongoClient>;
 
 // Enhanced connection logic with automatic fallback
 async function createMongoConnection(): Promise<MongoClient> {
@@ -97,6 +100,13 @@ async function createMongoConnection(): Promise<MongoClient> {
     await client.connect();
     return client;
   } catch (error) {
+    // The direct fallback targets `cluster:27017`, which an Atlas SRV cluster
+    // does not serve. In production it can only burn another timeout, so keep
+    // it to development where it exists for mobile-hotspot DNS issues.
+    if (process.env.NODE_ENV !== "development") {
+      throw error;
+    }
+
     console.warn(
       "Primary MongoDB SRV connection failed, trying direct connection...",
       error,
@@ -119,18 +129,33 @@ async function createMongoConnection(): Promise<MongoClient> {
   }
 }
 
-try {
-  if (process.env.NODE_ENV === "development") {
-    // In development, use a global variable to preserve the connection across hot-reloads
-    global._mongoClientPromise ??= createMongoConnection();
-    clientPromise = global._mongoClientPromise;
-  } else {
-    // In production, create a new connection
-    clientPromise = createMongoConnection();
-  }
-} catch (error) {
-  console.error("MongoDB connection initialization error:", error);
-  throw new Error("Failed to initialize MongoDB connection");
+function connect(): Promise<MongoClient> {
+  // A rejected promise stays cached for the life of the instance, so a single
+  // transient failure would break every later request. Evict it instead.
+  const pending = createMongoConnection().catch((error) => {
+    if (global._mongoClientPromise === pending) {
+      global._mongoClientPromise = undefined;
+    }
+    throw error;
+  });
+  return pending;
 }
 
-export default clientPromise;
+/**
+ * Always read the client through this. It re-reads the cache, so a connection
+ * evicted after a failure is retried instead of returning the rejected promise
+ * forever.
+ */
+export function getMongoClient(): Promise<MongoClient> {
+  // Cached on `global` in every environment: it survives dev hot-reloads, and in
+  // production it stops a second module instance from opening a second pool.
+  global._mongoClientPromise ??= connect();
+  return global._mongoClientPromise;
+}
+
+// Start connecting at import time so the handshake overlaps with module
+// evaluation rather than blocking the first query.
+void getMongoClient().catch(() => {
+  // Swallowed here; callers surface the failure. Prevents an unhandled
+  // rejection when nothing has awaited the client yet.
+});

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -15,6 +15,12 @@ declare module "next-auth" {
   }
 }
 
+declare module "next-auth/jwt" {
+  interface JWT {
+    userId?: string;
+  }
+}
+
 export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
@@ -23,16 +29,35 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    async session({ session }) {
-      if (session.user?.email) {
-        const db = await getDb();
-        const user = await db
-          .collection("users")
-          .findOne({ email: session.user.email }, { projection: { _id: 1 } });
+    // Resolve the user id once and cache it on the JWT. `getServerSession` runs
+    // these callbacks on every authenticated API request, so looking the user up
+    // here instead of in `session` removes a MongoDB round trip from each one.
+    async jwt({ token }) {
+      if (!token.userId && token.email) {
+        try {
+          const db = await getDb();
+          const user = await db
+            .collection("users")
+            .findOne({ email: token.email }, { projection: { _id: 1 } });
 
-        if (user?._id) {
-          session.user.id = user._id.toString();
+          // `events.signIn` creates the document *after* this callback first
+          // runs, so leave the id unset and retry on the next request rather
+          // than caching a miss.
+          if (user?._id) {
+            token.userId = user._id.toString();
+          }
+        } catch (error) {
+          // A database blip must not throw out of this callback: NextAuth would
+          // return an empty session and sign the user out. Keep the token and
+          // retry the lookup on the next request instead.
+          console.error("Failed to resolve user id for session token:", error);
         }
+      }
+      return token;
+    },
+    session({ session, token }) {
+      if (session.user && token.userId) {
+        session.user.id = token.userId;
       }
       return session;
     },

--- a/src/pages/api/user/index.ts
+++ b/src/pages/api/user/index.ts
@@ -5,7 +5,7 @@ import type { Session } from "next-auth";
 import { getDb } from "src/utils/db";
 import { authOptions } from "../auth/[...nextauth]";
 
-import clientPromise from "../../../clients/mongo";
+import { getMongoClient } from "../../../clients/mongo";
 
 type ResponseData = { message: string };
 
@@ -26,7 +26,7 @@ export default async function handler(
   }
 
   try {
-    const client = await clientPromise;
+    const client = await getMongoClient();
     const db = await getDb();
 
     // Start a session for transaction

--- a/src/utils/db/getDb.ts
+++ b/src/utils/db/getDb.ts
@@ -1,6 +1,6 @@
-import clientPromise from "src/clients/mongo";
+import { getMongoClient } from "src/clients/mongo";
 
 export async function getDb() {
-  const client = await clientPromise;
+  const client = await getMongoClient();
   return client.db(process.env.MONGODB_DB);
 }


### PR DESCRIPTION
## Problem

Launching the app could take many seconds, and sometimes appeared to sign the user out.

Two causes, both on the authentication path:

**1. A MongoDB query on every authenticated request.** `callbacks.session` looked the user up by email to populate `session.user.id`. Every API route calls `getServerSession`, which runs that callback, so each request paid an extra round trip before doing any real work.

**2. Connection settings that turn a blip into a hang.** `serverSelectionTimeoutMS` was only set in development, so production used the driver's 30s default. When that expired, the SRV connection fell back to a direct connection against `cluster:27017` — which an Atlas SRV cluster does not serve — burning a second timeout. The rejected promise was then cached for the life of the instance, so that instance never recovered.

## Fix

Resolve the user id once in `callbacks.jwt` and cache it on the token. NextAuth re-encodes and re-sets the session cookie after running the callback ([`core/routes/session.js`](https://github.com/nextauthjs/next-auth/blob/v4/packages/next-auth/src/core/routes/session.ts)), so later requests read the id from the JWT with no database access.

`events.signIn` creates the user document *after* `callbacks.jwt` first runs, so a missing document is retried rather than cached as a miss. A failed lookup no longer throws — that returned an empty session and signed the user out.

On the connection: `serverSelectionTimeoutMS` now applies in production, the direct-connection fallback is development-only (where it exists for mobile-hotspot DNS issues), a rejected promise is evicted so the next request retries, and `maxPoolSize` drops 50 → 10 since serverless multiplies the pool by instance count.

## Measured

Against an unreachable database, identical requests:

| case | before | after |
|---|---|---|
| session with a cached id | 41144ms, empty body | **60ms**, valid session |
| session without one | 41144ms, empty body | **24ms**, valid session |

The empty body matters as much as the time: the old path signed the user out whenever the database was slow.

## Tests

Five new cases in `src/__tests__/api/auth/nextauth.test.ts` covering the cache, the no-query steady state, the new-user retry, and the failure path. **Three of them fail against the unmodified baseline.**

Full suite 367 passing, lint clean, production build clean with all static routes preserved and shared JS unchanged at 195 kB.
