### PR TITLE
perf: shrink the shared bundle, fix the production build, and stop shipping tests as API routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@
 │   ├── server/             # Server-side utilities
 │   ├── clients/            # External API clients
 │   └── stories/            # Storybook stories
-├── tests/                  # Unit and integration tests
+├── tests/                  # Playwright end-to-end specs (ignored by Jest)
 ├── public/                 # Static assets
 │   ├── icons/
 │   └── image/
@@ -83,6 +83,17 @@
 - Each component and hook should include a short comment on usage
 - Document top-level files (like `pages/_app.tsx`) and configs
 - Keep `README.md` up to date with getting started, design tokens, and component usage notes
+
+## 🧪 Test placement
+
+- Jest specs live in `src/**/__tests__/` or beside their subject as `*.test.ts(x)`.
+- **Never put a test file under `src/pages/`.** Every file there becomes a route,
+  so `src/pages/api/upload/__tests__/presign.test.ts` shipped as a live
+  `/api/upload/__tests__/presign.test` endpoint. API-route specs belong in
+  `src/__tests__/api/**`; import the handler by root-absolute path
+  (e.g. `src/pages/api/upload/presign`).
+- `tests/` holds Playwright specs only — `jest.config.js` ignores it, so a Jest
+  file placed there runs silently never.
 
 ## 🔐 Security
 

--- a/next.config.js
+++ b/next.config.js
@@ -70,6 +70,11 @@ const withBundleAnalyzer = bundleAnalyzer({
 const nextConfig = {
   reactStrictMode: true,
   serverExternalPackages: ["@tanstack/query-core"],
+  // Bundle (rather than externalize) this ESM-only package on the server.
+  // Externalizing it made every importer an async webpack module, which loses
+  // next/router's RouterContext during static prerendering. Its CJS entry is a
+  // 4.9 MB all-icons monolith, so requiring it is not an option either.
+  transpilePackages: ["@phosphor-icons/react"],
   experimental: {
     reactCompiler: {
       target: "19",
@@ -101,7 +106,49 @@ const nextConfig = {
         "@radix-ui/react-dialog",
         "@radix-ui/react-dropdown-menu",
         "@radix-ui/react-tooltip",
+        // Each of these is ESM-first and turned its importers (AppShell,
+        // AppSidebar, RecipeSearchFlyout, ...) into async webpack modules,
+        // which lost RouterContext during static prerendering. All ship a CJS
+        // main and no "type": "module", so requiring them synchronously is safe.
+        // @phosphor-icons/react is deliberately excluded: it sets
+        // "type": "module" while its CJS entry is a .js file, so require() of it
+        // throws "exports is not defined in ES module scope".
+        "@radix-ui/react-select",
+        "@radix-ui/react-accordion",
+        "cmdk",
+        "embla-carousel-react",
+        "@dnd-kit/core",
+        "@dnd-kit/sortable",
+        "@dnd-kit/modifiers",
+        "next-auth/react",
       ];
+      const isForcedCommonJs = (request) => {
+        if (FORCE_COMMONJS.includes(request)) {
+          return true;
+        }
+        // The Lexical family is ESM-only and made the whole editor subtree async
+        // webpack modules on the server, which lost next/router's RouterContext
+        // during static prerendering. Every package ships a CJS entry.
+        // @lexical/code is excluded so the PrismJS-stripping alias below still
+        // applies -- externalizing it would pull PrismJS back into the build.
+        if (request === "@lexical/code" || request.startsWith("@lexical/code/")) {
+          return false;
+        }
+        return (
+          request === "lexical" ||
+          request.startsWith("@lexical/") ||
+          // package.json sets "type": "module", so webpack resolved Next's ESM
+          // build (next/dist/esm/**) for app code while the Pages Router
+          // renderer uses the CJS build. That duplicated
+          // router-context.shared-runtime, so every useRouter() call in the app
+          // tree read a different context instance than the renderer provided
+          // and threw "NextRouter was not mounted" during static prerendering.
+          /^next\/(router|document|link|head|image|script|dynamic)$/.test(
+            request,
+          )
+        );
+      };
+
       const existingExternals = Array.isArray(config.externals)
         ? config.externals
         : config.externals
@@ -109,7 +156,7 @@ const nextConfig = {
           : [];
       config.externals = [
         ({ request }, callback) => {
-          if (FORCE_COMMONJS.includes(request)) {
+          if (request && isForcedCommonJs(request)) {
             return callback(null, `commonjs ${request}`);
           }
           callback();

--- a/src/__tests__/api/upload/confirm.test.ts
+++ b/src/__tests__/api/upload/confirm.test.ts
@@ -26,8 +26,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth";
 
 import { r2 } from "src/lib/r2";
+import handler from "src/pages/api/upload/confirm";
 import { getDb } from "src/utils/db";
-import handler from "../confirm";
 
 const mockGetServerSession = getServerSession as jest.Mock;
 const mockGetDb = getDb as jest.Mock;

--- a/src/__tests__/api/upload/presign.test.ts
+++ b/src/__tests__/api/upload/presign.test.ts
@@ -23,8 +23,8 @@ jest.mock("@aws-sdk/s3-request-presigner", () => ({
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth";
 
+import handler from "src/pages/api/upload/presign";
 import { getDb } from "src/utils/db";
-import handler from "../presign";
 
 const mockGetServerSession = getServerSession as jest.Mock;
 const mockGetDb = getDb as jest.Mock;

--- a/src/components/AppShell/AppShell.test.tsx
+++ b/src/components/AppShell/AppShell.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { email: "cook@example.com" } } }),
+}));
+jest.mock("next/router", () => ({
+  useRouter: () => ({ pathname: "/recipes", push: jest.fn() }),
+}));
+jest.mock("../../clientToServer/fetch/fetchRecentlyViewed", () => ({
+  fetchRecentlyViewed: jest.fn().mockResolvedValue([]),
+}));
+jest.mock("../../clientToServer/post/useCreateRecipe", () => ({
+  useCreateRecipe: () => ({ mutate: jest.fn() }),
+}));
+jest.mock("../../hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+}));
+jest.mock("../Sidebar", () => ({
+  AppSidebar: ({ onSearch }: { onSearch: () => void }) => (
+    <button onClick={onSearch}>Open search</button>
+  ),
+}));
+jest.mock("../RecipeSearchFlyout", () => ({
+  RecipeSearchFlyout: () => <div data-testid="search-flyout" />,
+}));
+
+import { AppShell } from "./AppShell";
+
+const renderShell = (): void => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AppShell>
+        <p>page content</p>
+      </AppShell>
+    </QueryClientProvider>,
+  );
+};
+
+describe("AppShell search flyout deferral", () => {
+  it("renders page content without mounting the search flyout", () => {
+    renderShell();
+
+    expect(screen.getByText("page content")).toBeInTheDocument();
+    expect(screen.queryByTestId("search-flyout")).not.toBeInTheDocument();
+  });
+
+  it("mounts the search flyout only once search is opened", async () => {
+    renderShell();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open search" }));
+
+    expect(await screen.findByTestId("search-flyout")).toBeInTheDocument();
+  });
+});

--- a/src/components/AppShell/AppShell.tsx
+++ b/src/components/AppShell/AppShell.tsx
@@ -30,7 +30,6 @@ const RecipeSearchFlyout = dynamic(
   { ssr: false },
 );
 
-
 export type AppShellProps = {
   children: React.ReactNode;
 };

--- a/src/components/AppShell/AppShell.tsx
+++ b/src/components/AppShell/AppShell.tsx
@@ -6,17 +6,30 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 
 import styles from "./AppShell.module.css";
-import { RecipeSearchFlyout } from "../RecipeSearchFlyout";
 import { AppSidebar } from "../Sidebar";
 
 import { fetchRecentlyViewed } from "../../clientToServer/fetch/fetchRecentlyViewed";
 import { useCreateRecipe } from "../../clientToServer/post/useCreateRecipe";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
+
+// A closed Radix dialog renders nothing, so the search flyout contributed
+// @radix-ui/react-dialog and its own subtree to the shared _app chunk on every
+// route while being invisible until the user opens search. Deferring it leaves
+// the server markup byte-identical; the idle preload below keeps opening
+// instant, so the bytes are merely moved off the critical path.
+const loadSearchFlyout = () => import("../RecipeSearchFlyout");
+
+const RecipeSearchFlyout = dynamic(
+  () => loadSearchFlyout().then((mod) => ({ default: mod.RecipeSearchFlyout })),
+  { ssr: false },
+);
+
 
 export type AppShellProps = {
   children: React.ReactNode;
@@ -28,6 +41,7 @@ export const AppShell = ({ children }: AppShellProps) => {
   const isMobile = useMediaQuery("(max-width: 640px)");
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [hasOpenedSearch, setHasOpenedSearch] = useState(false);
   const [profileMenuOpen, setProfileMenuOpen] = useState(false);
   const { mutate: createRecipe } = useCreateRecipe();
 
@@ -44,6 +58,7 @@ export const AppShell = ({ children }: AppShellProps) => {
 
   const handleSearch = (): void => {
     setDrawerOpen(false);
+    setHasOpenedSearch(true);
     setIsSearchOpen(true);
   };
 
@@ -65,6 +80,18 @@ export const AppShell = ({ children }: AppShellProps) => {
       },
     );
   };
+
+  // Warm the deferred search chunk once the page is idle so the first search
+  // click opens instantly without those bytes blocking first paint.
+  useEffect(() => {
+    const preload = (): void => void loadSearchFlyout();
+    if (typeof window.requestIdleCallback === "function") {
+      const id = window.requestIdleCallback(preload);
+      return () => window.cancelIdleCallback(id);
+    }
+    const timer = setTimeout(preload, 2000);
+    return () => clearTimeout(timer);
+  }, []);
 
   // Close drawer on route change
   useEffect(() => {
@@ -89,11 +116,13 @@ export const AppShell = ({ children }: AppShellProps) => {
 
   return (
     <div className={styles.shell}>
-      <RecipeSearchFlyout
-        open={isSearchOpen}
-        onOpenChange={setIsSearchOpen}
-        recentRecipes={recentRecipes}
-      />
+      {hasOpenedSearch && (
+        <RecipeSearchFlyout
+          open={isSearchOpen}
+          onOpenChange={setIsSearchOpen}
+          recentRecipes={recentRecipes}
+        />
+      )}
 
       {/* Mobile top header — hidden on desktop via CSS */}
       <header className={styles.mobileHeader}>

--- a/src/components/Toolbar/SearchBar/SearchBar.test.tsx
+++ b/src/components/Toolbar/SearchBar/SearchBar.test.tsx
@@ -3,7 +3,7 @@ import { jest } from "@jest/globals";
 
 import { SearchBar } from "./SearchBar";
 
-import { render } from "../../../utils";
+import { render } from "../../../utils/testing";
 
 jest.mock("../../../context", () => ({
   useSearchBox: () => ({

--- a/src/pages/meal-plan.tsx
+++ b/src/pages/meal-plan.tsx
@@ -9,7 +9,7 @@ import { Spinner } from "../components/Spinner";
 const MealPlanCalendar = dynamic(
   () =>
     import("../components/MealPlan/MealPlanCalendar/MealPlanCalendar").then(
-      (mod) => mod.MealPlanCalendar,
+      (mod) => ({ default: mod.MealPlanCalendar }),
     ),
   {
     loading: () => <Spinner size="large" />,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,5 @@
-export * from "./testing";
+// Production-only barrel. Test helpers live in `src/utils/testing` and must be
+// imported from there directly: re-exporting them here pulled
+// @testing-library/react and next-router-mock into the server bundle, which
+// duplicated next/router's RouterContext and broke static prerendering.
 export * from "./fetchJson";


### PR DESCRIPTION
Two commits: the unpushed build fix from the previous session, plus two newly measured performance wins.

## 1. `fix(build)`: production build was broken on `main`

`next build` failed for every static page with "NextRouter was not mounted", so 0 of 7 pages prerendered and no production bundle existed.

Root cause: `package.json` sets `"type": "module"`, so webpack resolved Next's ESM build (`next/dist/esm/**`) for app code while the Pages Router renderer uses the CJS build. `next/router` and `next/document` were duplicated, so the app read a different `RouterContext`/`HtmlContext` instance than the renderer provided. ESM-only packages (Lexical, Radix, cmdk, dnd-kit, embla) being externalized as async webpack modules compounded it.

## 2. `perf`: stop shipping Jest files as live API routes

Next routes **every** file under `src/pages`, and nothing restricted `pageExtensions`, so the build emitted real serverless functions:

```
ƒ /api/upload/__tests__/confirm.test
ƒ /api/upload/__tests__/presign.test
```

Mocked test handlers were publicly routable. Moved to `src/__tests__/api/upload/`, matching the existing `src/__tests__/api/auth` spec. They can't go in `tests/` — `jest.config.js` ignores that path for Playwright, so Jest would stop running them silently. Documented the rule in `CLAUDE.md` so it can't regress.

## 3. `perf`: defer the recipe search flyout

`AppShell` rendered `RecipeSearchFlyout` unconditionally even though it's invisible until the user opens search. Webpack stats for the shared `pages/_app` chunk showed it parking `@radix-ui/react-dialog` (13.1 KB), `visually-hidden` (1.0 KB), the flyout, its CSS and `fetchAllRecipes` into the chunk **every route loads**.

A closed Radix dialog renders nothing, so `next/dynamic` leaves prerendered markup byte-identical — unlike the earlier attempt to defer `AppShell` itself, which emptied `<div id="__next">`. An idle-time preload keeps the first search click instant, so the bytes are moved off the critical path rather than traded for latency.

## Measured result

First Load JS, before → after:

| Route | Before | After | Δ |
|---|---|---|---|
| **shared by all** | 195 kB | **190 kB** | −5 kB |
| `chunks/pages/_app` | 93.4 kB | **89.4 kB** | −4 kB |
| `/` | 192 kB | 187 kB | −5 kB |
| `/recipes` | 213 kB | 212 kB | −1 kB |
| `/discover` | 207 kB | 204 kB | −3 kB |
| `/settings` | 192 kB | 186 kB | −6 kB |
| `/meal-plan` | 192 kB | 187 kB | −5 kB |
| `/recipes/[recipes]` | 191 kB | 186 kB | −5 kB |
| `/404` | 191 kB | 187 kB | −4 kB |

Every route got smaller and two routes disappeared from the server build.

## Validation

- `yarn lint` → `✔ No ESLint warnings or errors`
- `yarn test` → 367 passed, 1 skipped, 44 suites
- `yarn build` → succeeds, all 7 pages prerender real SSR markup (`recipes.html` 5.6 KB, no empty `__next`, no dialog markup while closed)
